### PR TITLE
fix(db)!: trade_history 스키마 불일치 수정 — 주문 체결 후 크래시 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ MANIFEST
 venv/
 env/
 ENV/
+kairos_env
 kairos_env/
 .venv/
 

--- a/kairos1_main.py
+++ b/kairos1_main.py
@@ -232,9 +232,18 @@ class KairosSimple:
             if report.success:
                 executed += 1
                 self._daily_traded_krw += req.amount_krw
-                self.portfolio.record_trade(
-                    req.asset, req.side, req.amount_krw, origin=req.origin
-                )
+                # 주문은 이미 체결됨 — 기록 실패가 나머지 주문 실행을 막으면 안 됨
+                try:
+                    self.portfolio.record_trade(
+                        req.asset, req.side, req.amount_krw, origin=req.origin
+                    )
+                except Exception as e:
+                    logger.error(f"거래 기록 실패 (주문은 체결됨): {req.asset} — {e}")
+                    self.alerts.send_error_alert(
+                        "거래 기록 실패",
+                        f"{req.side} {req.asset} {req.amount_krw:,.0f} KRW 주문은 "
+                        f"체결됐으나 DB 기록 실패: {e}",
+                    )
             else:
                 rejected.append((req.asset, f"실행 실패: {report.error}"))
         result = {"executed": executed, "rejected": rejected, "halted": False}

--- a/kairos_env
+++ b/kairos_env
@@ -1,1 +1,0 @@
-/Users/jongdal100/git/coinone-agent/kairos_env

--- a/src/portfolio/portfolio.py
+++ b/src/portfolio/portfolio.py
@@ -46,10 +46,9 @@ class PortfolioService:
 
     def record_trade(self, asset: str, side: str, amount_krw: float, origin: str) -> None:
         self.db.save_trade({
-            "currency": asset,
+            "asset": asset,
             "side": side,
-            "order_type": origin,       # "dca" | "rebalance"
-            "amount": amount_krw,
-            "status": "executed",
-            "created_at": datetime.now(),
+            "amount_krw": amount_krw,
+            "origin": origin,           # "dca" | "rebalance"
+            "trade_date": datetime.now(),
         })

--- a/src/utils/database_manager.py
+++ b/src/utils/database_manager.py
@@ -163,9 +163,32 @@ class DatabaseManager:
                         fee_krw REAL,
                         order_id TEXT,
                         execution_id TEXT,
+                        origin TEXT,
                         created_at TEXT DEFAULT CURRENT_TIMESTAMP
                     )
                 """)
+
+                # 구버전 DB 마이그레이션: trade_history에 누락된 컬럼 추가
+                # (과거 배포본이 다른 스키마로 테이블을 만든 경우 대비)
+                cursor.execute("PRAGMA table_info(trade_history)")
+                existing_cols = {row[1] for row in cursor.fetchall()}
+                required_cols = {
+                    "trade_date": "TEXT",
+                    "asset": "TEXT",
+                    "side": "TEXT",
+                    "price": "REAL DEFAULT 0",
+                    "quantity": "REAL DEFAULT 0",
+                    "amount_krw": "REAL DEFAULT 0",
+                    "fee_krw": "REAL",
+                    "order_id": "TEXT",
+                    "execution_id": "TEXT",
+                    "origin": "TEXT",
+                }
+                for col, col_type in required_cols.items():
+                    if col not in existing_cols:
+                        cursor.execute(
+                            f"ALTER TABLE trade_history ADD COLUMN {col} {col_type}"
+                        )
 
                 # 리밸런싱 결과 테이블
                 cursor.execute("""
@@ -467,42 +490,42 @@ class DatabaseManager:
     
     def save_trade(self, trade_info: Dict) -> int:
         """
-        거래 내역 저장
-        
+        거래 내역 저장 — trade_history 정식 스키마(asset/amount_krw) 사용
+
         Args:
             trade_info: 거래 정보
-            
+                필수: asset, side, amount_krw
+                선택: price, quantity, fee_krw, order_id, origin, trade_date
+
         Returns:
             저장된 레코드 ID
         """
         try:
             with self.get_connection() as conn:
                 cursor = conn.cursor()
-                
+
                 cursor.execute("""
-                    INSERT OR REPLACE INTO trade_history (
-                        order_id, currency, side, order_type, amount, price,
-                        filled_amount, average_price, fee, status, trade_date
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO trade_history (
+                        trade_date, asset, side, price, quantity,
+                        amount_krw, fee_krw, order_id, origin
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
-                    trade_info.get("order_id"),
-                    trade_info.get("currency"),
-                    trade_info.get("side"),
-                    trade_info.get("order_type"),
-                    trade_info.get("amount"),
-                    trade_info.get("price"),
-                    trade_info.get("filled_amount", 0),
-                    trade_info.get("average_price", 0),
-                    trade_info.get("fee", 0),
-                    trade_info.get("status"),
-                    trade_info.get("created_at", datetime.now())
+                    str(trade_info.get("trade_date", datetime.now())),
+                    trade_info["asset"],
+                    trade_info["side"],
+                    trade_info.get("price", 0.0),
+                    trade_info.get("quantity", 0.0),
+                    trade_info["amount_krw"],
+                    trade_info.get("fee_krw", 0.0),
+                    trade_info.get("order_id", ""),
+                    trade_info.get("origin", ""),
                 ))
-                
+
                 record_id = cursor.lastrowid
                 conn.commit()
-                
+
                 return record_id
-                
+
         except Exception as e:
             logger.error(f"거래 내역 저장 실패: {e}")
             raise

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1432,69 +1432,76 @@ class TestConnectionError:
 
 @pytest.mark.database
 class TestSaveTrade:
-    """거래 내역 저장 테스트"""
+    """거래 내역 저장 테스트 — 실제 DDL 스키마 그대로 사용.
+
+    회귀 방지: 과거 이 픽스처가 자체 테이블을 만들어 DDL 불일치를 가렸고,
+    운영에서 'no column named currency'로 주문 체결 후 크래시가 발생했다.
+    """
 
     @pytest.fixture
     def db_manager(self, tmp_path):
-        """DatabaseManager 인스턴스"""
+        """DatabaseManager 인스턴스 (실제 초기화 DDL 그대로)"""
         db_path = str(tmp_path / "test.db")
         config = Mock()
         config.get = Mock(return_value=db_path)
-        db = DatabaseManager(config)
-        # trade_history 테이블 수정
-        with db.get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("DROP TABLE IF EXISTS trade_history")
-            cursor.execute("""
-                CREATE TABLE trade_history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    order_id TEXT,
-                    currency TEXT,
-                    side TEXT,
-                    order_type TEXT,
-                    amount REAL,
-                    price REAL,
-                    filled_amount REAL,
-                    average_price REAL,
-                    fee REAL,
-                    status TEXT,
-                    trade_date TEXT,
-                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            conn.commit()
-        return db
+        return DatabaseManager(config)
 
     def test_save_trade(self, db_manager):
-        """거래 내역 저장"""
+        """거래 내역 저장 — 정식 스키마(asset/amount_krw) 컬럼"""
         trade_info = {
-            "order_id": "test_order_001",
-            "currency": "BTC",
+            "asset": "BTC",
             "side": "buy",
-            "order_type": "market",
-            "amount": 0.01,
-            "price": 50000000,
-            "filled_amount": 0.01,
-            "average_price": 50100000,
-            "fee": 500,
-            "status": "filled",
-            "created_at": datetime.now()
+            "amount_krw": 500_000.0,
+            "price": 50_000_000.0,
+            "quantity": 0.01,
+            "fee_krw": 500.0,
+            "order_id": "test_order_001",
+            "origin": "dca",
+            "trade_date": datetime.now(),
         }
 
         record_id = db_manager.save_trade(trade_info)
 
         assert record_id > 0
+        saved = db_manager.get_trade_history(days=1)
+        assert saved and saved[0]["asset"] == "BTC"
+        assert saved[0]["amount_krw"] == 500_000.0
 
     def test_save_trade_minimal(self, db_manager):
-        """최소 정보로 거래 내역 저장"""
-        trade_info = {
-            "order_id": "test_order_002",
-            "currency": "ETH",
-            "side": "sell"
-        }
+        """최소 정보(자산·방향·금액)만으로도 저장 — NOT NULL 컬럼은 기본값"""
+        record_id = db_manager.save_trade({
+            "asset": "ETH",
+            "side": "sell",
+            "amount_krw": 100_000.0,
+        })
+        assert record_id > 0
 
-        record_id = db_manager.save_trade(trade_info)
+    def test_save_trade_migrates_legacy_table(self, tmp_path):
+        """구버전(currency 스키마) 테이블도 초기화 시 자동 마이그레이션"""
+        db_path = str(tmp_path / "legacy.db")
+        import sqlite3
+        conn = sqlite3.connect(db_path)
+        conn.execute("""
+            CREATE TABLE trade_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id TEXT,
+                currency TEXT,
+                side TEXT,
+                amount REAL
+            )
+        """)
+        conn.commit()
+        conn.close()
 
+        config = Mock()
+        config.get = Mock(return_value=db_path)
+        db = DatabaseManager(config)  # 초기화 시 누락 컬럼 추가되어야 함
+
+        record_id = db.save_trade({
+            "asset": "XRP",
+            "side": "sell",
+            "amount_krw": 1_173_000.0,
+        })
         assert record_id > 0
 
 

--- a/tests/test_kairos_main.py
+++ b/tests/test_kairos_main.py
@@ -140,3 +140,16 @@ def test_config_from_loader_defaults():
     config = KairosSimple.config_from_loader(loader)
     assert config.rebalance.crypto_target == 0.60
     assert config.limits.min_krw_ratio == 0.10
+
+
+def test_record_trade_failure_does_not_abort_remaining_orders():
+    """운영 회귀 방지: 주문 체결 후 DB 기록 실패가 나머지 주문 실행을
+    중단시키면 안 된다 (돈은 이미 움직였으므로 기록 실패는 경고로 강등)."""
+    holdings = {"BTC": 50_000_000, "ETH": 12_000_000, "XRP": 4_000_000, "SOL": 4_000_000}
+    sys_, executor, alerts = make_system(holdings=holdings, krw=30_000_000)
+    sys_.portfolio.record_trade.side_effect = Exception("table trade_history has no column named currency")
+    result = sys_.run_daily_check(dry_run=False)
+    # 리밸런싱 주문이 여러 건인데, 첫 기록 실패에도 전부 실행 시도되어야 함
+    assert executor.execute.call_count >= 2
+    assert result["executed"] >= 2
+    assert alerts.send_error_alert.called  # 기록 실패는 알림으로 통지

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -52,6 +52,7 @@ def test_record_trade_persists_to_db():
     svc.record_trade("BTC", "buy", 500_000.0, origin="dca")
     assert db.save_trade.called
     saved = db.save_trade.call_args.args[0]
-    assert saved["currency"] == "BTC"
+    assert saved["asset"] == "BTC"          # trade_history DDL 컬럼과 일치해야 함
     assert saved["side"] == "buy"
-    assert saved["amount"] == 500_000.0
+    assert saved["amount_krw"] == 500_000.0
+    assert saved["origin"] == "dca"


### PR DESCRIPTION
운영 장애: save_trade가 DDL에 없는 currency 컬럼에 INSERT하여
XRP 매도 체결 직후 크래시, 잔여 리밸런싱 주문 미실행.
(기존 테스트 픽스처가 자체 테이블을 만들어 불일치를 가리고 있었음)

- save_trade를 정식 스키마(asset/amount_krw/origin)로 재작성
- 초기화 시 누락 컬럼 자동 마이그레이션 (구버전 DB 대응)
- 주문 체결 후 기록 실패는 경고+알림으로 강등, 잔여 주문 계속 실행
- 실수로 커밋된 kairos_env 심링크 제거 + .gitignore 보강