### PR TITLE
fix(execution): 지정가 호가 단위 정렬 — 코인원 오류 310 수정

### DIFF
--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -65,6 +65,14 @@ class OrderExecutor:
                 limit = price * (
                     1 + SLIPPAGE_CAP if order.side == "buy" else 1 - SLIPPAGE_CAP
                 )
+                # 코인원 호가 단위 정렬 (오류 310 방지):
+                # 매수는 내림(캡 준수), 매도는 올림(하한 준수)
+                # 1e-9 보정: 부동소수점 오차로 한 틱이 잘리는 것 방지
+                unit = self.coinone.get_price_unit(order.asset, limit)
+                if order.side == "buy":
+                    limit = math.floor(limit / unit + 1e-9) * unit
+                else:
+                    limit = math.ceil(limit / unit - 1e-9) * unit
                 qty = slice_krw / limit
                 result = self.coinone.place_order(
                     currency=order.asset,

--- a/src/trading/coinone_client.py
+++ b/src/trading/coinone_client.py
@@ -53,6 +53,9 @@ class CoinoneClient:
         # KRW 마켓 기준으로 주요 코인들
         self.supported_coins = SUPPORTED_CRYPTOCURRENCIES + ["ADA", "DOT", "MATIC", "LINK"]
         self.quote_currency = "KRW"  # 기준 통화
+
+        # 호가 단위(Range Unit) 캐시: {currency: [(range_min, next_range_min, price_unit)]}
+        self._range_units_cache: Dict[str, list] = {}
     
     def _create_signature(self, request_body: Dict) -> Dict[str, str]:
         """
@@ -314,6 +317,54 @@ class CoinoneClient:
         except Exception as e:
             logger.error(f"{currency} 최신 가격 조회 실패: {e}")
             return 0.0
+
+    # 코인원 표준 호가 단위 테이블 (Range Unit API 실패 시 폴백)
+    # (range_min, next_range_min, price_unit)
+    _DEFAULT_RANGE_UNITS = [
+        (0, 1, 0.0001), (1, 5, 0.001), (5, 10, 0.005), (10, 50, 0.01),
+        (50, 100, 0.05), (100, 500, 0.1), (500, 1_000, 0.5),
+        (1_000, 5_000, 1), (5_000, 10_000, 5), (10_000, 50_000, 10),
+        (50_000, 100_000, 50), (100_000, 500_000, 100),
+        (500_000, 1_000_000, 500), (1_000_000, 5_000_000, 1_000),
+        (5_000_000, 10_000_000, 5_000), (10_000_000, float("inf"), 10_000),
+    ]
+
+    def get_price_unit(self, currency: str, price: float) -> float:
+        """
+        지정가 주문의 호가 단위 조회 (오류 310 방지)
+
+        Range Unit API 응답을 통화별로 캐시하고, 실패 시 코인원 표준
+        호가 테이블로 폴백한다.
+
+        Args:
+            currency: 코인 심볼
+            price: 주문 가격 (KRW)
+
+        Returns:
+            해당 가격 구간의 호가 단위 (KRW)
+        """
+        currency = currency.upper()
+        units = self._range_units_cache.get(currency)
+        if units is None:
+            try:
+                response = self._make_request(
+                    "GET", f"/public/v2/range_units/{self.quote_currency}/{currency}",
+                    is_public=True,
+                )
+                units = [
+                    (float(u["range_min"]), float(u["next_range_min"]),
+                     float(u["price_unit"]))
+                    for u in response["range_price_units"]
+                ]
+                self._range_units_cache[currency] = units
+            except Exception as e:
+                logger.warning(f"{currency} 호가 단위 API 실패, 표준 테이블 사용: {e}")
+                units = self._DEFAULT_RANGE_UNITS
+
+        for range_min, next_range_min, price_unit in units:
+            if range_min <= price < next_range_min:
+                return price_unit
+        return units[-1][2]
 
     def _generate_nonce(self) -> str:
         """UUID nonce 생성"""

--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -10,6 +10,7 @@ from src.risk.guard import OrderRequest
 def make_executor(price=100_000_000.0, **kw):
     coinone = MagicMock()
     coinone.get_latest_price.return_value = price
+    coinone.get_price_unit.return_value = 1000.0  # 기본 호가 단위 (테스트 가격과 정렬됨)
     coinone.place_order.return_value = {"success": True, "order_id": "oid-1"}
     defaults = dict(twap_slice_krw=5_000_000, max_retries=3, retry_wait=0)
     defaults.update(kw)
@@ -86,3 +87,74 @@ def test_partial_fill_reported_on_mid_slice_failure():
     report = ex.execute(OrderRequest("BTC", "buy", 10_000_000, "rebalance"))
     assert not report.success
     assert report.filled_krw == pytest.approx(5_000_000)
+
+
+class TestPriceUnitRounding:
+    """운영 회귀 방지: 코인원 오류 310 — 지정가는 호가 단위에 맞춰야 함"""
+
+    def test_buy_limit_floored_to_price_unit(self):
+        # BTC 94,560,000 → 캡 95,032,800 → 단위 10,000원 → 95,030,000으로 내림
+        ex, coinone = make_executor(price=94_560_000.0)
+        coinone.get_price_unit.return_value = 10_000.0
+        ex.execute(OrderRequest("BTC", "buy", 1_000_000, "rebalance"))
+        kwargs = coinone.place_order.call_args.kwargs
+        assert kwargs["price"] == pytest.approx(95_030_000.0)
+        assert kwargs["price"] % 10_000 == 0
+        # 수량은 반올림된 지정가 기준으로 계산
+        assert kwargs["amount"] == pytest.approx(1_000_000 / 95_030_000.0)
+
+    def test_sell_limit_ceiled_to_price_unit(self):
+        # SOL 116,800 → 하한 116,216 → 단위 100원 → 116,300으로 올림
+        ex, coinone = make_executor(price=116_800.0)
+        coinone.get_price_unit.return_value = 100.0
+        ex.execute(OrderRequest("SOL", "sell", 1_000_000, "rebalance"))
+        kwargs = coinone.place_order.call_args.kwargs
+        assert kwargs["price"] == pytest.approx(116_300.0)
+        assert kwargs["price"] % 100 == 0
+
+
+class TestCoinoneGetPriceUnit:
+    """CoinoneClient.get_price_unit — Range Unit API 조회·캐시·폴백"""
+
+    def make_client(self):
+        from src.trading.coinone_client import CoinoneClient
+        client = CoinoneClient(api_key="k", secret_key="s")
+        return client
+
+    def test_price_unit_from_api(self):
+        from unittest.mock import patch
+        client = self.make_client()
+        api_response = {
+            "result": "success",
+            "range_price_units": [
+                {"range_min": 100000, "next_range_min": 500000, "price_unit": 100},
+                {"range_min": 1000000, "next_range_min": 5000000, "price_unit": 1000},
+            ],
+        }
+        with patch.object(client, "_make_request", return_value=api_response):
+            assert client.get_price_unit("SOL", 116_216.0) == 100
+            assert client.get_price_unit("SOL", 2_625_059.0) == 1000
+
+    def test_price_unit_cached_per_currency(self):
+        from unittest.mock import patch
+        client = self.make_client()
+        api_response = {
+            "result": "success",
+            "range_price_units": [
+                {"range_min": 0, "next_range_min": 10000000000, "price_unit": 100},
+            ],
+        }
+        with patch.object(client, "_make_request", return_value=api_response) as mock_req:
+            client.get_price_unit("SOL", 100_000.0)
+            client.get_price_unit("SOL", 200_000.0)
+            assert mock_req.call_count == 1  # 두 번째는 캐시
+
+    def test_price_unit_static_fallback_on_api_failure(self):
+        from unittest.mock import patch
+        client = self.make_client()
+        with patch.object(client, "_make_request", side_effect=Exception("down")):
+            # 코인원 표준 호가 테이블 폴백
+            assert client.get_price_unit("BTC", 94_560_000.0) == 10_000
+            assert client.get_price_unit("ETH", 2_612_000.0) == 1_000
+            assert client.get_price_unit("SOL", 116_800.0) == 100
+            assert client.get_price_unit("XRP", 1_638.0) == 1


### PR DESCRIPTION
구시스템은 시장가 주문이라 문제가 없었으나, 신규 executor가
슬리피지 상한용 지정가를 도입하며 호가 단위 반올림이 누락됨
(SOL 116,216원 → 단위 100원 위반 등으로 전 주문 거부).

- CoinoneClient.get_price_unit: Range Unit API 조회 + 통화별 캐시
  + API 실패 시 코인원 표준 호가 테이블 폴백
- executor: 매수 지정가는 단위 내림(캡 준수), 매도는 올림(하한 준수)
- 부동소수점 오차로 한 틱 잘림 방지 (1e-9 보정)