### PR TITLE
refactor(data): 미사용 get_multi_timeframe_data 메서드 제거

### DIFF
--- a/src/utils/binance_data_provider.py
+++ b/src/utils/binance_data_provider.py
@@ -6,7 +6,7 @@ Binance API를 통한 히스토리컬 데이터 제공자
 
 import pandas as pd
 from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
+from typing import Optional
 from binance.client import Client
 import nest_asyncio
 nest_asyncio.apply()  # 중첩된 이벤트 루프 허용
@@ -184,50 +184,6 @@ class BinanceDataProvider:
         except Exception as e:
             logger.error(f"BTC 데이터 수집 실패: {e}")
             return pd.DataFrame()
-    
-    def get_multi_timeframe_data(self, symbol: str = "BTCUSDT") -> Dict[str, pd.DataFrame]:
-        """
-        멀티 타임프레임 분석을 위한 데이터 수집
-        
-        Args:
-            symbol: 거래 심볼
-            
-        Returns:
-            타임프레임별 데이터 딕셔너리
-        """
-        try:
-            data = {}
-            
-            # 단기: 30일 일간 데이터
-            data['short'] = self.get_historical_klines(
-                symbol=symbol,
-                interval="1d",
-                start_date=datetime.now() - timedelta(days=30),
-                limit=30
-            )
-            
-            # 중기: 1년 일간 데이터
-            data['medium'] = self.get_historical_klines(
-                symbol=symbol,
-                interval="1d", 
-                start_date=datetime.now() - timedelta(days=365),
-                limit=365
-            )
-            
-            # 장기: 4년 주간 데이터
-            data['long'] = self.get_historical_klines(
-                symbol=symbol,
-                interval="1w",
-                start_date=datetime.now() - timedelta(weeks=208),
-                limit=208
-            )
-            
-            logger.info(f"멀티 타임프레임 데이터 수집 완료: {len(data)}개 타임프레임")
-            return data
-            
-        except Exception as e:
-            logger.error(f"멀티 타임프레임 데이터 수집 실패: {e}")
-            return None
     
     def convert_usdt_to_krw(
         self,

--- a/tests/test_binance_data_provider.py
+++ b/tests/test_binance_data_provider.py
@@ -267,59 +267,6 @@ class TestGetBTCPriceDataForAnalysis:
         assert df.empty
 
 
-class TestGetMultiTimeframeData:
-    """get_multi_timeframe_data 테스트"""
-
-    @pytest.fixture
-    def mock_klines(self):
-        """샘플 캔들 데이터"""
-        return [
-            [1609459200000, '30000', '31000', '29500', '30500', '1000',
-             1609545599999, '30500000', 5000, '500', '15250000', '0'],
-            [1609545600000, '30500', '32000', '30000', '31500', '1200',
-             1609631999999, '37800000', 6000, '600', '18900000', '0'],
-        ]
-
-    @pytest.fixture
-    def provider(self):
-        with patch('src.utils.binance_data_provider.Client'):
-            return BinanceDataProvider()
-
-    def test_get_multi_timeframe_data_success(self, provider, mock_klines):
-        """멀티 타임프레임 데이터 수집 성공"""
-        provider.client.get_historical_klines.return_value = mock_klines
-
-        data = provider.get_multi_timeframe_data(symbol="BTCUSDT")
-
-        assert 'short' in data
-        assert 'medium' in data
-        assert 'long' in data
-        assert len(data) == 3
-
-    def test_get_multi_timeframe_data_with_empty_klines(self, provider):
-        """빈 캔들 데이터 시"""
-        provider.client.get_historical_klines.return_value = []
-
-        data = provider.get_multi_timeframe_data(symbol="BTCUSDT")
-
-        # 빈 데이터프레임을 가진 딕셔너리 반환
-        assert 'short' in data
-        assert 'medium' in data
-        assert 'long' in data
-        assert data['short'].empty
-        assert data['medium'].empty
-        assert data['long'].empty
-
-    def test_get_multi_timeframe_data_exception_at_top_level(self, provider):
-        """최상위 예외 발생 시"""
-        # get_multi_timeframe_data 자체에서 예외 발생
-        provider.get_historical_klines = Mock(side_effect=Exception("Complete failure"))
-
-        data = provider.get_multi_timeframe_data(symbol="BTCUSDT")
-
-        assert data is None
-
-
 class TestConvertUSDTToKRW:
     """convert_usdt_to_krw 테스트"""
 


### PR DESCRIPTION
2026-07 KAIROS-Simple 개편에서 멀티 타임프레임 분석 모듈이
삭제된 후 프로덕션 코드에서 호출하는 곳이 없는 데드 코드 정리

- BinanceDataProvider.get_multi_timeframe_data 메서드 삭제
- 해당 테스트 클래스 TestGetMultiTimeframeData 삭제 (테스트 3개)
- 미사용 typing import (Dict, Any) 정리
- 전체 테스트 776개 통과 확인