### PR TITLE
feat(monitoring): Slack 완결성 — 크래시 알림 + 거래 판단 근거

### DIFF
--- a/kairos1_main.py
+++ b/kairos1_main.py
@@ -183,7 +183,7 @@ class KairosSimple:
         base = self.config.rebalance.crypto_target
         return contrarian_crypto_target(mayer, base) if self.config.contrarian_tilt else base
 
-    def _effective_weights(self) -> Dict[str, float]:
+    def _effective_weights(self, notes=None) -> Dict[str, float]:
         """모든 사이클이 공유하는 단일 자산 가중치 — 상대강도 편출 반영.
 
         26주 BTC 대비 열위 알트의 가중치를 연속 감축(감축분은 BTC로).
@@ -197,26 +197,30 @@ class KairosSimple:
         demoted = {a: w for a, w in effective.items()
                    if abs(w - weights[a]) > 1e-9}
         if demoted:
-            logger.info(
-                "상대강도 편출: "
-                + ", ".join(f"{a} {weights[a]:.0%}→{w:.1%}"
-                            for a, w in sorted(demoted.items()))
+            msg = "상대강도 편출: " + ", ".join(
+                f"{a} {weights[a]:.0%}→{w:.1%}" for a, w in sorted(demoted.items())
             )
+            logger.info(msg)
+            if notes is not None:
+                notes.append(msg)
         return effective
 
     def run_weekly_dca(self, dry_run: bool = False) -> Dict:
+        return self._guarded("주간 DCA", lambda: self._weekly_dca(dry_run))
+
+    def run_daily_check(self, dry_run: bool = False) -> Dict:
+        return self._guarded("일일 밴드 체크", lambda: self._daily_check(dry_run))
+
+    def _weekly_dca(self, dry_run: bool) -> Dict:
         """주간 DCA: 공포·저평가일수록 많이 매수.
 
         단, 매수 후 크립토 비중이 (틸트된) 목표를 넘지 않도록 상한 —
         목표 도달 시 현금을 보존해 다음 하락 매집 재원으로 남긴다."""
         import dataclasses
 
-        try:
-            valuation = self.market.get_valuation()
-            weights = self._effective_weights()
-            snap = self.portfolio.get_snapshot()
-        except (DataUnavailableError, InsufficientDataError) as e:
-            return self._halt("주간 DCA", e)
+        valuation = self.market.get_valuation()
+        weights = self._effective_weights()
+        snap = self.portfolio.get_snapshot()
         mult = dca_multiplier(valuation)
         target = self._tilted_target(valuation.mayer_ratio)
         dca_cfg = dataclasses.replace(self.config.dca, crypto_weights=weights)
@@ -224,15 +228,16 @@ class KairosSimple:
             dca_cfg, mult, snap.krw_balance,
             crypto_value_krw=snap.crypto_value_krw, target_crypto_ratio=target,
         )
-        logger.info(
-            f"DCA 승수 {mult:.2f} (F&G={valuation.fear_greed}, "
-            f"Mayer={valuation.mayer_ratio:.2f}) | 크립토 {snap.crypto_ratio:.1%}"
-            f"/목표 {target:.1%} → 주문 {len(orders)}건"
-        )
+        notes = [
+            f"승수 {mult:.2f} (F&G={valuation.fear_greed}, "
+            f"Mayer={valuation.mayer_ratio:.2f}) | "
+            f"크립토 {snap.crypto_ratio:.1%} → 목표 {target:.1%}"
+        ]
+        logger.info(f"{notes[0]} → 주문 {len(orders)}건")
         if not orders and snap.crypto_ratio >= target:
             logger.info("목표 비중 도달 — 이번 주 DCA 현금 보존")
         requests = [OrderRequest(o.asset, "buy", o.amount_krw, "dca") for o in orders]
-        result = self._execute_all("주간 DCA", requests, snap, dry_run)
+        result = self._execute_all("주간 DCA", requests, snap, dry_run, notes=notes)
         if not dry_run and result["executed"] == 0 and not result["rejected"]:
             # 주간 하트비트 — 무거래 주에도 최소 주 1회 알림이 가야
             # '조용한 시장'과 '죽은 크론'을 구분할 수 있다
@@ -244,57 +249,62 @@ class KairosSimple:
             )
         return result
 
-    def run_daily_check(self, dry_run: bool = False) -> Dict:
+    def _daily_check(self, dry_run: bool) -> Dict:
         """일일 밴드 체크: 이탈 시에만 목표 비중으로 복귀.
 
         역발상 틸트가 켜져 있으면 Mayer ratio로 목표 비중을 연속 조절한다
         (바닥권일수록 높게, 과열일수록 낮게)."""
         import dataclasses
 
+        notes = []
+        reb_cfg = self.config.rebalance
+        if self.config.contrarian_tilt:
+            mayer = self.market.get_mayer_ratio()
+            target = self._tilted_target(mayer)
+            if target != reb_cfg.crypto_target:
+                msg = (f"역발상 틸트: Mayer={mayer:.2f} → 목표 "
+                       f"{reb_cfg.crypto_target:.0%} → {target:.1%}")
+                logger.info(msg)
+                notes.append(msg)
+            reb_cfg = dataclasses.replace(reb_cfg, crypto_target=target)
+        reb_cfg = dataclasses.replace(
+            reb_cfg, crypto_weights=self._effective_weights(notes)
+        )
+        snap = self.portfolio.get_snapshot()
         try:
-            reb_cfg = self.config.rebalance
-            if self.config.contrarian_tilt:
-                mayer = self.market.get_mayer_ratio()
-                target = self._tilted_target(mayer)
-                if target != reb_cfg.crypto_target:
-                    logger.info(
-                        f"역발상 틸트: Mayer={mayer:.2f} → 목표 "
-                        f"{reb_cfg.crypto_target:.0%} → {target:.1%}"
-                    )
-                reb_cfg = dataclasses.replace(reb_cfg, crypto_target=target)
-            reb_cfg = dataclasses.replace(
-                reb_cfg, crypto_weights=self._effective_weights()
-            )
-            snap = self.portfolio.get_snapshot()
-            try:
-                # 월간 수익률 데이터 축적 — 기록 실패가 거래를 막으면 안 됨
-                self.portfolio.record_snapshot(snap)
-            except Exception as e:
-                logger.error(f"스냅샷 기록 실패 (체크는 계속): {e}")
-            orders = plan_rebalance(reb_cfg, snap.holdings_krw, snap.krw_balance)
-            if not orders:
-                logger.info(f"밴드 내 (크립토 {snap.crypto_ratio:.1%}) — 거래 없음")
-                return {"executed": 0, "rejected": [], "halted": False,
-                        "note": "밴드 내 — 거래 없음"}
-            changes = self.market.get_price_change_24h([o.asset for o in orders])
-            guarded = apply_crash_guard(
-                orders, changes,
-                threshold=reb_cfg.crash_threshold,
-                buy_fraction=reb_cfg.crash_buy_fraction,
-                min_trade_krw=reb_cfg.min_trade_krw,
-            )
-            if guarded != orders:
-                logger.info("크래시 가드: 급락 자산 매수 분할 진입 적용")
-            orders = guarded
-        except (DataUnavailableError, InsufficientDataError) as e:
-            return self._halt("일일 밴드 체크", e)
+            # 월간 수익률 데이터 축적 — 기록 실패가 거래를 막으면 안 됨
+            self.portfolio.record_snapshot(snap)
+        except Exception as e:
+            logger.error(f"스냅샷 기록 실패 (체크는 계속): {e}")
+        orders = plan_rebalance(reb_cfg, snap.holdings_krw, snap.krw_balance)
+        if not orders:
+            logger.info(f"밴드 내 (크립토 {snap.crypto_ratio:.1%}) — 거래 없음")
+            return {"executed": 0, "rejected": [], "halted": False,
+                    "note": "밴드 내 — 거래 없음"}
+        notes.insert(0, f"크립토 {snap.crypto_ratio:.1%} → 목표 "
+                        f"{reb_cfg.crypto_target:.1%} 복귀")
+        changes = self.market.get_price_change_24h([o.asset for o in orders])
+        guarded = apply_crash_guard(
+            orders, changes,
+            threshold=reb_cfg.crash_threshold,
+            buy_fraction=reb_cfg.crash_buy_fraction,
+            min_trade_krw=reb_cfg.min_trade_krw,
+        )
+        if guarded != orders:
+            msg = "크래시 가드: 급락 자산 매수 분할 진입"
+            logger.info(msg)
+            notes.append(msg)
+        orders = guarded
         requests = [
             OrderRequest(o.asset, o.side, o.amount_krw, "rebalance") for o in orders
         ]
         return self._execute_all("밴드 리밸런싱", requests, snap, dry_run,
-                                 price_changes=changes)
+                                 price_changes=changes, notes=notes)
 
     def run_monthly_report(self) -> Dict:
+        return self._guarded("월간 리포트", self._monthly_report)
+
+    def _monthly_report(self) -> Dict:
         from src.report.reporter import Reporter
 
         snap = self.portfolio.get_snapshot()
@@ -331,7 +341,8 @@ class KairosSimple:
         }
 
     # ---------------------------------------------------------------- 내부
-    def _execute_all(self, label, requests, snap, dry_run, price_changes=None) -> Dict:
+    def _execute_all(self, label, requests, snap, dry_run,
+                     price_changes=None, notes=None) -> Dict:
         executed, rejected = 0, []
         executed_reqs = []
         # 매도 먼저 실행해 KRW 확보 후 매수 (하락장 리밸런싱 매수 자금)
@@ -381,16 +392,18 @@ class KairosSimple:
         result = {"executed": executed, "rejected": rejected, "halted": False}
         logger.info(f"{label} 완료: 실행 {executed}건, 거부 {len(rejected)}건")
         if not dry_run:
-            self._notify_result(label, executed_reqs, rejected)
+            self._notify_result(label, executed_reqs, rejected, notes)
         return result
 
-    def _notify_result(self, label, executed_reqs, rejected) -> None:
+    def _notify_result(self, label, executed_reqs, rejected, notes=None) -> None:
         """체결·거부 내역 Slack 통지 — 무거래 날은 조용히 (알림 피로 방지).
 
+        판단 근거(notes: 틸트·편출·승수·가드)를 함께 실어 서버 로그 없이
+        Slack만으로 왜 거래했는지 이해할 수 있게 한다.
         알림 실패가 사이클 결과를 바꾸면 안 됨 (주문은 이미 체결됨)."""
         if not executed_reqs and not rejected:
             return
-        lines = [
+        lines = [f"📐 {n}" for n in (notes or [])] + [
             f"✅ {r.side} {r.asset} {r.amount_krw:,.0f} KRW" for r in executed_reqs
         ] + [f"🚫 {asset}: {reason}" for asset, reason in rejected]
         body = "\n".join(lines)
@@ -406,9 +419,30 @@ class KairosSimple:
         except Exception as e:
             logger.error(f"Slack 알림 실패 (거래는 정상 처리됨): {e}")
 
+    def _guarded(self, label: str, fn) -> Dict:
+        """무인 운영 가드 — 어떤 실패도 조용히 죽지 않고 Slack에 남긴다."""
+        try:
+            return fn()
+        except (DataUnavailableError, InsufficientDataError) as e:
+            return self._halt(label, e)
+        except Exception as e:
+            return self._crash(label, e)
+
     def _halt(self, label: str, error: Exception) -> Dict:
         logger.error(f"{label} 중단: {error}")
         self.alerts.send_warning_alert(f"{label} 중단", f"데이터 이상: {error}")
+        return {"executed": 0, "rejected": [], "halted": True, "error": str(error)}
+
+    def _crash(self, label: str, error: Exception) -> Dict:
+        """예상치 못한 예외 — 데이터 이상(warning)과 구분해 error로 통지."""
+        logger.exception(f"{label} 비정상 종료: {error}")
+        try:
+            self.alerts.send_error_alert(
+                f"{label} 비정상 종료",
+                f"예상치 못한 오류로 사이클 중단: {error}",
+            )
+        except Exception as alert_err:
+            logger.error(f"오류 알림 발송도 실패: {alert_err}")
         return {"executed": 0, "rejected": [], "halted": True, "error": str(error)}
 
 

--- a/tests/test_kairos_main.py
+++ b/tests/test_kairos_main.py
@@ -302,6 +302,50 @@ def test_monthly_report_without_history_notes_accumulating():
     assert "축적" in body
 
 
+def test_unexpected_exception_sends_error_alert_and_halts():
+    """서버 로그를 못 보는 무인 운영: 어떤 오류도 조용히 죽으면 안 됨 —
+    데이터 오류(warning)가 아닌 예상치 못한 예외는 error 알림 + 중단"""
+    sys_, _, alerts = make_system()
+    sys_.portfolio.get_snapshot.side_effect = RuntimeError("boom")
+    result = sys_.run_daily_check(dry_run=False)
+    assert result["halted"]
+    alerts.send_error_alert.assert_called_once()
+
+
+def test_execution_phase_exception_also_alerts():
+    """플래닝뿐 아니라 실행 단계 예외도 알림 커버"""
+    holdings = {
+        "BTC": 40_000_000, "ETH": 24_000_000, "XRP": 8_000_000, "SOL": 8_000_000
+    }
+    sys_, executor, alerts = make_system(holdings=holdings, krw=20_000_000)
+    executor.execute.side_effect = RuntimeError("unexpected")
+    result = sys_.run_daily_check(dry_run=False)
+    assert result["halted"]
+    alerts.send_error_alert.assert_called_once()
+
+
+def test_rebalance_alert_includes_decision_context():
+    """거래 알림에 판단 근거(비중/목표) 포함 — Slack만 보고 이해 가능해야"""
+    holdings = {
+        "BTC": 40_000_000, "ETH": 24_000_000, "XRP": 8_000_000, "SOL": 8_000_000
+    }
+    sys_, _, alerts = make_system(holdings=holdings, krw=20_000_000)
+    sys_.run_daily_check(dry_run=False)
+    _, body = alerts.send_info_alert.call_args.args
+    assert "목표" in body and "80.0%" in body  # 현재 비중 80% → 목표로 복귀
+
+
+def test_dca_alert_includes_multiplier_context():
+    holdings = {
+        "BTC": 20_000_000, "ETH": 12_000_000, "XRP": 4_000_000, "SOL": 4_000_000
+    }
+    sys_, _, alerts = make_system(fg=20, mayer=1.5, holdings=holdings,
+                                  krw=60_000_000)
+    sys_.run_weekly_dca(dry_run=False)
+    _, body = alerts.send_info_alert.call_args.args
+    assert "승수" in body and "F&G" in body
+
+
 def test_sells_execute_before_buys():
     """매도 먼저 실행해 KRW 확보 후 매수"""
     holdings = {"BTC": 50_000_000, "ETH": 12_000_000, "XRP": 4_000_000, "SOL": 4_000_000}
@@ -432,3 +476,11 @@ def test_record_trade_failure_does_not_abort_remaining_orders():
     assert executor.execute.call_count >= 2
     assert result["executed"] >= 2
     assert alerts.send_error_alert.called  # 기록 실패는 알림으로 통지
+
+
+def test_monthly_report_exception_sends_error_alert():
+    sys_, _, alerts = make_system()
+    sys_.portfolio.get_snapshot.side_effect = RuntimeError("boom")
+    result = sys_.run_monthly_report()
+    assert result["halted"]
+    alerts.send_error_alert.assert_called_once()


### PR DESCRIPTION
## 배경

사용자가 서버에 상시 접속하기 어려움 → Slack만으로 시스템 상태를 완전히 파악할 수 있어야 한다. 기존 커버리지의 두 구멍을 보완:

1. **예상치 못한 크래시가 조용했음** — 데이터 오류(DataUnavailable/InsufficientData)만 warning 알림, 그 외 예외(버그, API 인증 실패, 네트워크)는 로그에만 남고 침묵
2. **거래 알림에 맥락이 없었음** — "sell XRP 3,000,000 KRW"만 보이고 왜 팔았는지(편출? 틸트? 밴드?)는 서버 로그를 열어야 알 수 있었음

## 변경

- **`_guarded` 무인 운영 가드**: 세 사이클 전체(플래닝+실행)를 감싸 어떤 예외도 error 알림 + halted 처리. 알림 발송 자체가 실패해도 로그 남기고 안전 종료
- **판단 근거(📐 notes)를 거래 알림에 포함**: `크립토 80.0% → 목표 60.0% 복귀`, `승수 2.00 (F&G=20, Mayer=1.50)`, `역발상 틸트: Mayer=0.85 → 목표 72.5%`, `상대강도 편출: XRP 10%→5.0%`, `크래시 가드: 급락 자산 매수 분할 진입`

이제 Slack 커버리지: 체결/부분체결/거부(사유·근거 포함), 데이터 이상 중단, 비정상 크래시, DB 기록 실패, 주간 하트비트, 월간 리포트 — 로그 파일에만 남는 주요 이벤트 없음.

## 검증
TDD: 신규 테스트 5개 (RED 확인 후 구현), 전체 **851개 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)