### PR TITLE
feat(monitoring): 데일리 브리핑 — 매일 발송되는 잔고 현황 + 생존 신호

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -143,6 +143,10 @@ crontab -e
 # 일일 밴드 체크 (매일 09:10) — 목표 ±5%p 이탈 시에만 리밸런싱
 10 9 * * * cd /path/to/kairos-1 && kairos_env/bin/python kairos1_main.py daily-check >> /var/log/kairos/daily-check.log 2>&1
 
+# 데일리 브리핑 (매일 09:20) — 잔고·비중·시장 상태를 매일 Slack 발송.
+# daily-check 이후에 돌려 당일 리밸런싱이 반영된 상태로 전달한다.
+20 9 * * * cd /path/to/kairos-1 && kairos_env/bin/python kairos1_main.py briefing >> /var/log/kairos/briefing.log 2>&1
+
 # 월간 리포트 (매월 1일 09:30)
 30 9 1 * * cd /path/to/kairos-1 && kairos_env/bin/python kairos1_main.py report >> /var/log/kairos/report.log 2>&1
 ```
@@ -158,11 +162,11 @@ crontab -e
 #     서버 로컬 시간 기준이다. 반드시 KST로 맞출 것:
 sudo timedatectl set-timezone Asia/Seoul
 
-# (2) 크론 생존 감시 (dead-man switch) — 무거래 날은 Slack이 조용하므로
-#     '조용한 시장'과 '죽은 크론'을 핑으로 구분한다 (healthchecks.io 무료):
-#     daily-check 크론 라인 끝에 붙이기:
-#     ... kairos1_main.py daily-check >> /var/log/kairos/daily-check.log 2>&1 && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null
-#     (주간 DCA는 코드 내 하트비트 알림이 매주 월요일 무조건 발송됨)
+# (2) 크론 생존 감시 (dead-man switch) — 데일리 브리핑(09:20)이 매일
+#     무조건 Slack으로 발송되므로, 브리핑이 하루라도 끊기면 시스템 이상.
+#     Slack 자체 장애까지 커버하려면 healthchecks.io 핑을 병행 (선택):
+#     briefing 크론 라인 끝에 붙이기:
+#     ... kairos1_main.py briefing >> /var/log/kairos/briefing.log 2>&1 && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null
 
 # (3) 로그 로테이션 — /etc/logrotate.d/kairos:
 cat <<'CONF' | sudo tee /etc/logrotate.d/kairos

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ src/
 ├── risk/guard.py            # 단일 리스크 관문
 ├── execution/executor.py    # 지정가(슬리피지 0.5% 상한)·재시도·TWAP 분할
 ├── portfolio/portfolio.py   # 잔고 스냅샷·거래 기록
-└── report/reporter.py       # 성과 리포트 (벤치마크 = 실제 BTC 보유 수익률)
+├── report/reporter.py       # 성과 리포트 (벤치마크 = 실제 BTC 보유 수익률)
+└── report/briefing.py       # 데일리 브리핑 (매일 발송 — 잔고 + 생존 신호)
 ```
 
 ## 사용법
@@ -65,6 +66,7 @@ export COINONE_API_KEY=... COINONE_SECRET_KEY=...
 
 python kairos1_main.py weekly-dca --dry-run    # 주간 DCA (매주 월 09:00 권장)
 python kairos1_main.py daily-check --dry-run   # 일일 밴드 체크 (매일 09:00 권장)
+python kairos1_main.py briefing                # 데일리 브리핑 (매일 09:20 권장)
 python kairos1_main.py report                  # 월간 성과 리포트
 python kairos1_main.py status                  # 현재 포트폴리오 상태
 ```
@@ -72,10 +74,14 @@ python kairos1_main.py status                  # 현재 포트폴리오 상태
 `--dry-run`을 빼면 실제 주문이 나갑니다. 스케줄링은 cron 예시:
 
 ```cron
-0 9 * * 1  cd /path/to/repo && python kairos1_main.py weekly-dca
-0 9 * * *  cd /path/to/repo && python kairos1_main.py daily-check
-0 9 1 * *  cd /path/to/repo && python kairos1_main.py report
+0 9 * * 1   cd /path/to/repo && python kairos1_main.py weekly-dca
+0 9 * * *   cd /path/to/repo && python kairos1_main.py daily-check
+20 9 * * *  cd /path/to/repo && python kairos1_main.py briefing
+0 9 1 * *   cd /path/to/repo && python kairos1_main.py report
 ```
+
+브리핑은 무거래 날에도 매일 발송됩니다 — 잔고·비중·시장 상태를 전하는
+동시에, 알림이 하루라도 끊기면 시스템 이상을 바로 알 수 있는 생존 신호입니다.
 
 ## 백테스트
 

--- a/kairos1_main.py
+++ b/kairos1_main.py
@@ -18,7 +18,7 @@
 심리)는 목표 아래에서 신규 현금의 투입 속도만 조절한다.
 
 파이프라인: market_data → strategy(순수 함수) → risk_guard → executor → record/alert
-CLI: python kairos1_main.py {weekly-dca|daily-check|report|status} [--dry-run]
+CLI: python kairos1_main.py {weekly-dca|daily-check|briefing|report|status} [--dry-run]
 """
 import argparse
 import sys
@@ -301,6 +301,38 @@ class KairosSimple:
         return self._execute_all("밴드 리밸런싱", requests, snap, dry_run,
                                  price_changes=changes, notes=notes)
 
+    def run_daily_briefing(self) -> Dict:
+        return self._guarded("데일리 브리핑", self._daily_briefing)
+
+    def _daily_briefing(self) -> Dict:
+        """데일리 브리핑: 무거래 날에도 매일 발송되는 잔고 현황 + 생존 신호.
+
+        핵심은 잔고와 '살아있음' — 시장 데이터 실패로 브리핑 자체가 죽으면
+        안 되므로 시장 라인만 실패 표기로 강등한다. 잔고 조회 실패는
+        _guarded가 에러 알림으로 통지 (어느 쪽이든 매일 무언가는 도착)."""
+        from src.report.briefing import compose_briefing
+
+        snap = self.portfolio.get_snapshot()
+        try:
+            valuation = self.market.get_valuation()
+            target = self._tilted_target(valuation.mayer_ratio)
+            market_line = (f"Mayer {valuation.mayer_ratio:.2f} | "
+                           f"F&G {valuation.fear_greed}")
+        except (DataUnavailableError, InsufficientDataError) as e:
+            target = self.config.rebalance.crypto_target
+            market_line = f"조회 실패 ({e})"
+        title, body = compose_briefing(
+            snap,
+            target_ratio=target,
+            band_pp=self.config.rebalance.band_pp,
+            market_line=market_line,
+            prev_total_krw=self.portfolio.get_previous_total_krw(),
+            traded_today_krw=self._daily_traded_krw,
+        )
+        self.alerts.send_info_alert(title, body)
+        return {"executed": 0, "rejected": [], "halted": False,
+                "note": "브리핑 발송"}
+
     def run_monthly_report(self) -> Dict:
         return self._guarded("월간 리포트", self._monthly_report)
 
@@ -449,7 +481,8 @@ class KairosSimple:
 def main() -> int:
     parser = argparse.ArgumentParser(description="KAIROS-Simple 장기 역발상 매집")
     parser.add_argument(
-        "command", choices=["weekly-dca", "daily-check", "report", "status"]
+        "command",
+        choices=["weekly-dca", "daily-check", "briefing", "report", "status"],
     )
     parser.add_argument("--dry-run", action="store_true", help="주문 없이 시뮬레이션")
     parser.add_argument("--config", default="config/config.yaml")
@@ -460,6 +493,8 @@ def main() -> int:
         result = system.run_weekly_dca(dry_run=args.dry_run)
     elif args.command == "daily-check":
         result = system.run_daily_check(dry_run=args.dry_run)
+    elif args.command == "briefing":
+        result = system.run_daily_briefing()
     elif args.command == "report":
         result = system.run_monthly_report()
     else:

--- a/src/portfolio/portfolio.py
+++ b/src/portfolio/portfolio.py
@@ -74,6 +74,20 @@ class PortfolioService:
             return None
         return current_total_krw / baseline - 1.0
 
+    def get_previous_total_krw(self):
+        """오늘 이전 가장 최근 스냅샷의 총자산 — 데일리 브리핑 전일 대비용.
+
+        이력이 없으면 None — 데이터 없이 변화율을 주장하지 않는다.
+        """
+        today = datetime.now().strftime("%Y-%m-%d")
+        totals = [
+            float(row["total_value_krw"])
+            for row in self.db.get_portfolio_history(7)
+            if float(row.get("total_value_krw") or 0) > 0
+            and str(row.get("snapshot_date", ""))[:10] < today
+        ]
+        return totals[-1] if totals else None
+
     def record_trade(self, asset: str, side: str, amount_krw: float, origin: str) -> None:
         self.db.save_trade({
             "asset": asset,

--- a/src/report/briefing.py
+++ b/src/report/briefing.py
@@ -1,0 +1,43 @@
+"""데일리 브리핑 — 매일 무조건 발송하는 잔고 현황 + 생존 신호.
+
+무거래 날 Slack이 조용하면 '조용한 시장'과 '죽은 시스템'을 구분할 수 없다.
+브리핑은 거래 여부와 무관하게 매일 도착해야 한다.
+"""
+from typing import Optional, Tuple
+
+from src.portfolio.portfolio import PortfolioSnapshot
+
+
+def compose_briefing(
+    snap: PortfolioSnapshot,
+    target_ratio: float,
+    band_pp: float,
+    market_line: str,
+    prev_total_krw: Optional[float],
+    traded_today_krw: float,
+) -> Tuple[str, str]:
+    """브리핑 (제목, 본문) 구성 — 순수 함수, 외부 호출 없음."""
+    total = snap.total_value_krw
+    if prev_total_krw:
+        change = f"전일 {total / prev_total_krw - 1.0:+.1%}"
+    else:
+        change = "전일 대비 — 데이터 축적 중"
+
+    deviation = snap.crypto_ratio - target_ratio
+    if abs(deviation) > band_pp:
+        band = f"밴드 이탈 {deviation:+.1%}p → 리밸런싱 예정"
+    else:
+        band = f"밴드 내 (±{band_pp:.1%}p)"
+
+    holdings = " | ".join(
+        f"{asset} {value:,.0f}" for asset, value in snap.holdings_krw.items()
+    )
+    body = "\n".join([
+        f"총자산 {total:,.0f} KRW ({change})",
+        f"크립토 {snap.crypto_ratio:.1%} / 목표 {target_ratio:.1%} — {band}",
+        holdings,
+        f"KRW 잔고 {snap.krw_balance:,.0f}",
+        f"시장: {market_line}",
+        f"오늘 거래 {traded_today_krw:,.0f} KRW",
+    ])
+    return "데일리 브리핑", body

--- a/src/utils/database_manager.py
+++ b/src/utils/database_manager.py
@@ -489,7 +489,12 @@ class DatabaseManager:
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     datetime.now(),
-                    portfolio_data.get("total_krw", 0),
+                    # record_snapshot은 total_value_krw로, 구 호출부는 total_krw로
+                    # 넘긴다 — 한쪽만 읽으면 총자산이 0으로 저장돼 월간 수익률·
+                    # 전일 대비가 영원히 '축적 중'이 된다
+                    portfolio_data.get(
+                        "total_value_krw", portfolio_data.get("total_krw", 0)
+                    ),
                     krw_balance,
                     btc_balance, btc_value,
                     eth_balance, eth_value,

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1,0 +1,92 @@
+"""데일리 브리핑 메시지 구성 테스트 — 매일 발송되는 생존 신호 + 잔고 현황."""
+from datetime import datetime
+
+import pytest
+
+from src.portfolio.portfolio import PortfolioSnapshot
+from src.report.briefing import compose_briefing
+
+
+def make_snapshot(holdings=None, krw=40_000_000):
+    holdings = holdings or {
+        "BTC": 30_000_000, "ETH": 18_000_000, "XRP": 6_000_000, "SOL": 6_000_000
+    }
+    return PortfolioSnapshot(
+        holdings_krw=holdings, krw_balance=krw, taken_at=datetime.now()
+    )
+
+
+def test_briefing_includes_total_and_daily_change():
+    """총자산과 전일 대비 변화율이 본문에 있어야 함"""
+    snap = make_snapshot()  # 총자산 100M
+    _, body = compose_briefing(
+        snap, target_ratio=0.60, band_pp=0.05, market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=98_000_000, traded_today_krw=0.0,
+    )
+    assert "100,000,000" in body
+    assert "+2.0%" in body
+
+
+def test_briefing_without_history_notes_accumulating():
+    """전일 스냅샷이 없으면 수익률을 주장하지 않고 축적 중임을 알림"""
+    _, body = compose_briefing(
+        make_snapshot(), target_ratio=0.60, band_pp=0.05,
+        market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=None, traded_today_krw=0.0,
+    )
+    assert "축적" in body
+    assert "%" not in body.split("\n")[0] or "+" not in body.split("\n")[0]
+
+
+def test_briefing_shows_ratio_vs_target_within_band():
+    """크립토 비중 vs 목표 + 밴드 내 상태 표시"""
+    _, body = compose_briefing(
+        make_snapshot(), target_ratio=0.60, band_pp=0.05,
+        market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=None, traded_today_krw=0.0,
+    )
+    assert "60.0%" in body and "목표" in body
+    assert "밴드 내" in body
+
+
+def test_briefing_flags_band_breach():
+    """밴드 이탈 시 다음 리밸런싱 예고가 보여야 함"""
+    holdings = {
+        "BTC": 40_000_000, "ETH": 24_000_000, "XRP": 8_000_000, "SOL": 8_000_000
+    }
+    _, body = compose_briefing(
+        make_snapshot(holdings=holdings, krw=20_000_000),  # 크립토 80%
+        target_ratio=0.60, band_pp=0.05, market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=None, traded_today_krw=0.0,
+    )
+    assert "밴드 이탈" in body
+
+
+def test_briefing_lists_each_asset_and_krw():
+    _, body = compose_briefing(
+        make_snapshot(), target_ratio=0.60, band_pp=0.05,
+        market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=None, traded_today_krw=0.0,
+    )
+    for asset in ("BTC", "ETH", "XRP", "SOL"):
+        assert asset in body
+    assert "40,000,000" in body  # KRW 잔고
+
+
+def test_briefing_includes_market_line_and_traded_amount():
+    _, body = compose_briefing(
+        make_snapshot(), target_ratio=0.65, band_pp=0.05,
+        market_line="Mayer 0.90 | F&G 20",
+        prev_total_krw=None, traded_today_krw=1_500_000.0,
+    )
+    assert "Mayer 0.90" in body and "F&G 20" in body
+    assert "1,500,000" in body
+
+
+def test_briefing_negative_daily_change():
+    snap = make_snapshot()  # 100M
+    _, body = compose_briefing(
+        snap, target_ratio=0.60, band_pp=0.05, market_line="Mayer 1.50 | F&G 50",
+        prev_total_krw=104_000_000, traded_today_krw=0.0,
+    )
+    assert "-3.8%" in body

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -641,6 +641,27 @@ class TestSavePortfolioSnapshot:
 
         assert record_id > 0
 
+    def test_save_portfolio_snapshot_persists_total_value_krw(self, db_manager):
+        """회귀 방지: PortfolioService.record_snapshot이 넘기는 total_value_krw
+        키가 그대로 저장돼야 함 — total_krw만 읽으면 총자산이 전부 0으로
+        기록돼 월간 수익률·전일 대비가 영원히 '축적 중'이 된다"""
+        db_manager.save_portfolio_snapshot({
+            "total_value_krw": 100_000_000.0,
+            "assets": {
+                "KRW": 40_000_000.0,
+                "BTC": {"balance": 0.0, "value_krw": 60_000_000.0},
+            },
+        })
+        history = db_manager.get_portfolio_history(days=1)
+        assert len(history) == 1
+        assert float(history[0]["total_value_krw"]) == pytest.approx(100_000_000.0)
+
+    def test_save_portfolio_snapshot_legacy_total_krw_still_works(self, db_manager):
+        """기존 호출부 호환: total_krw 키도 계속 인식"""
+        db_manager.save_portfolio_snapshot({"total_krw": 5_000_000, "assets": {}})
+        history = db_manager.get_portfolio_history(days=1)
+        assert float(history[0]["total_value_krw"]) == pytest.approx(5_000_000.0)
+
 
 @pytest.mark.database
 class TestTwapExecutionPlan:

--- a/tests/test_kairos_main.py
+++ b/tests/test_kairos_main.py
@@ -484,3 +484,59 @@ def test_monthly_report_exception_sends_error_alert():
     result = sys_.run_monthly_report()
     assert result["halted"]
     alerts.send_error_alert.assert_called_once()
+
+
+# ------------------------------------------------------------- 데일리 브리핑
+def test_daily_briefing_always_sends_even_without_trades():
+    """브리핑은 무거래 날에도 무조건 발송 — 매일 오는 생존 신호"""
+    sys_, _, alerts = make_system()  # 밴드 내, 거래 없음
+    sys_.portfolio.get_previous_total_krw.return_value = None
+    result = sys_.run_daily_briefing()
+    assert not result["halted"]
+    alerts.send_info_alert.assert_called_once()
+    title, body = alerts.send_info_alert.call_args.args
+    assert "브리핑" in title
+    assert "총자산" in body and "100,000,000" in body
+
+
+def test_daily_briefing_includes_tilted_target():
+    """바닥권(Mayer 0.8)이면 기본 60%가 아닌 틸트된 목표가 브리핑에 반영"""
+    from src.strategy.valuation import contrarian_crypto_target
+    sys_, _, alerts = make_system(mayer=0.8)
+    sys_.portfolio.get_previous_total_krw.return_value = None
+    sys_.run_daily_briefing()
+    _, body = alerts.send_info_alert.call_args.args
+    tilted = contrarian_crypto_target(0.8, 0.60)
+    assert f"목표 {tilted:.1%}" in body
+    assert "목표 60.0%" not in body
+
+
+def test_daily_briefing_survives_market_data_failure():
+    """브리핑의 핵심은 잔고+생존 신호 — 시장 데이터 실패로 죽으면 안 됨"""
+    sys_, _, alerts = make_system()
+    sys_.market.get_valuation.side_effect = DataUnavailableError("F&G down")
+    sys_.portfolio.get_previous_total_krw.return_value = None
+    result = sys_.run_daily_briefing()
+    assert not result["halted"]
+    alerts.send_info_alert.assert_called_once()
+    _, body = alerts.send_info_alert.call_args.args
+    assert "총자산" in body
+    assert "실패" in body  # 시장 데이터 실패도 숨기지 않고 표기
+
+
+def test_daily_briefing_balance_failure_sends_error_alert():
+    """잔고 조회 실패는 브리핑을 못 보내는 상황 — 에러 알림으로 대체
+    (어느 쪽이든 매일 무언가는 Slack에 도착해야 한다)"""
+    sys_, _, alerts = make_system()
+    sys_.portfolio.get_snapshot.side_effect = RuntimeError("API down")
+    result = sys_.run_daily_briefing()
+    assert result["halted"]
+    alerts.send_error_alert.assert_called_once()
+
+
+def test_daily_briefing_includes_daily_change_when_history_exists():
+    sys_, _, alerts = make_system()
+    sys_.portfolio.get_previous_total_krw.return_value = 98_000_000.0
+    sys_.run_daily_briefing()
+    _, body = alerts.send_info_alert.call_args.args
+    assert "+2.0%" in body

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -96,3 +96,35 @@ def test_value_change_30d_none_when_no_history():
     svc, db = make_service(balances={}, prices={})
     db.get_portfolio_history.return_value = []
     assert svc.get_value_change_30d(current_total_krw=100_000_000.0) is None
+
+
+def test_previous_total_uses_latest_snapshot_before_today():
+    """데일리 브리핑 전일 대비 — 오늘 이전의 가장 최근 스냅샷 기준"""
+    from datetime import datetime, timedelta
+    svc, db = make_service(balances={}, prices={})
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d 09:10:00")
+    day_before = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d 09:10:00")
+    today = datetime.now().strftime("%Y-%m-%d 09:10:00")
+    db.get_portfolio_history.return_value = [
+        {"snapshot_date": day_before, "total_value_krw": 90_000_000.0},
+        {"snapshot_date": yesterday, "total_value_krw": 95_000_000.0},
+        {"snapshot_date": today, "total_value_krw": 100_000_000.0},  # 오늘 것은 제외
+    ]
+    assert svc.get_previous_total_krw() == pytest.approx(95_000_000.0)
+
+
+def test_previous_total_skips_zero_rows():
+    """과거 버그로 total 0으로 저장된 행은 기준으로 쓰지 않는다"""
+    from datetime import datetime, timedelta
+    svc, db = make_service(balances={}, prices={})
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d 09:10:00")
+    db.get_portfolio_history.return_value = [
+        {"snapshot_date": yesterday, "total_value_krw": 0.0},
+    ]
+    assert svc.get_previous_total_krw() is None
+
+
+def test_previous_total_none_without_history():
+    svc, db = make_service(balances={}, prices={})
+    db.get_portfolio_history.return_value = []
+    assert svc.get_previous_total_krw() is None


### PR DESCRIPTION
## 배경

무거래 날은 Slack이 조용해서 "조용한 시장"인지 "죽은 시스템"인지 구분할 수 없었음. 매일 무조건 발송되는 잔고 브리핑을 추가해 이 문제를 해결.

## 변경 사항

### 신규: `briefing` 커맨드 (매일 09:20 크론 권장)
매일 Slack으로 발송:
- 총자산 KRW + 전일 대비 변화율 (스냅샷 이력 기반, 없으면 "축적 중")
- 크립토 비중 vs 틸트된 목표 + 밴드 상태 (이탈 시 리밸런싱 예고)
- 자산별 보유액, KRW 잔고
- 시장: Mayer ratio, Fear & Greed
- 오늘 거래액

발송 예시:
```
총자산 100,000,000 KRW (전일 +1.8%)
크립토 60.0% / 목표 60.0% — 밴드 내 (±5.0%p)
BTC 30,000,000 | ETH 18,000,000 | XRP 6,000,000 | SOL 6,000,000
KRW 잔고 40,000,000
시장: Mayer 1.42 | F&G 35
오늘 거래 0 KRW
```

### 안정성 설계
- 시장 데이터(F&G/Mayer) 실패 → 브리핑은 발송하고 실패 사실을 본문에 표기 (브리핑의 핵심은 잔고 + 생존 신호)
- 잔고 조회 실패 → 기존 `_guarded`가 에러 알림 발송 → **어느 쪽이든 매일 무언가는 Slack에 도착**

### 버그 수정 (기존)
`save_portfolio_snapshot`이 `total_krw` 키만 읽는데 `record_snapshot`은 `total_value_krw`로 넘겨서 일일 스냅샷의 총자산이 전부 0으로 저장되던 문제 수정. 월간 리포트가 영원히 "스냅샷 데이터 축적 중"이던 원인이었고, 브리핑의 전일 대비 계산에도 필요. (구 키도 계속 인식)

## 테스트
TDD로 진행 — 신규 15개 테스트 (compose 순수 함수 7, 오케스트레이션 5, DB 회귀 2, 전일 총자산 3). 전체 스위트 868개 통과.

## 배포 메모
EC2 crontab에 추가 필요:
```cron
20 9 * * * cd /path/to/kairos-1 && kairos_env/bin/python kairos1_main.py briefing >> /var/log/kairos/briefing.log 2>&1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)