### PR TITLE
fix: 전면 코드 리뷰 발견 버그 일괄 수정 — 치명 3건 포함 16건

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -7,8 +7,7 @@ api:
     api_key: "${COINONE_API_KEY}"
     secret_key: "${COINONE_SECRET_KEY}"
     sandbox: "${COINONE_SANDBOX:true}"
-    rate_limit: "${API_RATE_LIMIT_PER_MINUTE:100}"
-    timeout: "${API_REQUEST_TIMEOUT:30}"
+    timeout: "${API_REQUEST_TIMEOUT:30}"   # HTTP 요청 타임아웃(초)
 
 strategy:
   # 고정 목표 비중 — 시장 상황(강세/약세)에 따라 바꾸지 않는다.
@@ -20,11 +19,15 @@ strategy:
     # <1.0: +10%p(바닥권 매집) | 1-2: 기본 | 2-3: -10%p | >=3: -20%p(과열 익절)
     # 465주 32개 시작점 백테스트에서 고정 목표 대비 전 구간 동등 이상.
     contrarian_tilt: true
+    # 상대강도 편출: 26주 BTC 대비 열위 알트 가중치 연속 감축 (감축분은 BTC로)
+    relative_demotion: true
 
   rebalance:
     band_pp: 0.05         # 총 크립토 비중 ±5%p 이탈 시에만 거래 (수수료 대비 충분히 넓게)
     relative_band: 0.20   # 개별 코인 크립토 내 목표 대비 상대 ±20%
     min_trade_krw: 10000
+    crash_threshold_24h: -0.10   # 24h 이만큼 급락한 자산의 매수는 분할 진입
+    crash_buy_fraction: 0.5      # 급락 자산 매수 집행 비율 (잔여분은 다음날)
 
   dca:
     base_amount_krw: 1000000   # 주간 기본 매수액
@@ -36,17 +39,19 @@ risk:
   max_daily_volume_krw: 50000000   # 일일 거래량 상한 (5천만원)
   min_krw_ratio: 0.10              # 최소 KRW 비중 (전량 몰빵 방지)
   fomo_surge_threshold: 0.15       # 24h +15% 급등 자산은 DCA 외 매수 금지
-  data_max_age_hours: 24           # 데이터 신선도 한도
 
 execution:
   twap_slice_krw: 5000000   # 이 금액 초과 주문은 TWAP 분할
   slippage_cap: 0.005       # 지정가 슬리피지 상한 0.5%
   max_retries: 3
+  fill_timeout_sec: 45      # 체결 대기 타임아웃 — 초과 시 미체결 잔량 취소
+  poll_interval_sec: 3      # 체결 상태 폴링 간격
 
 scheduler:
-  weekly_dca:     { cron: "0 9 * * 1", timezone: "Asia/Seoul" }   # 매주 월 09:00
-  daily_check:    { cron: "0 9 * * *", timezone: "Asia/Seoul" }   # 매일 09:00
-  monthly_report: { cron: "0 9 1 * *", timezone: "Asia/Seoul" }   # 매월 1일 09:00
+  weekly_dca:      { cron: "0 9 * * 1", timezone: "Asia/Seoul" }   # 매주 월 09:00
+  daily_check:     { cron: "10 9 * * *", timezone: "Asia/Seoul" }  # 매일 09:10
+  daily_briefing:  { cron: "20 9 * * *", timezone: "Asia/Seoul" }  # 매일 09:20
+  monthly_report:  { cron: "0 9 1 * *", timezone: "Asia/Seoul" }   # 매월 1일 09:00
 
 notifications:
   email:

--- a/kairos1_main.py
+++ b/kairos1_main.py
@@ -155,6 +155,7 @@ class KairosSimple:
             api_key=loader.get("api.coinone.api_key"),
             secret_key=loader.get("api.coinone.secret_key"),
             sandbox=sandbox_raw in ("true", "1", "yes"),
+            timeout=float(loader.get("api.coinone.timeout", 30)),
         ))
         binance = BinanceDataProvider()
         external = ExternalAPIClient()
@@ -171,6 +172,7 @@ class KairosSimple:
             max_retries=int(loader.get("execution.max_retries", 3)),
             fill_timeout=float(loader.get("execution.fill_timeout_sec", 45)),
             poll_interval=float(loader.get("execution.poll_interval_sec", 3)),
+            slippage_cap=float(loader.get("execution.slippage_cap", 0.005)),
         )
         system = cls.from_components(market, portfolio, executor, alerts, config)
         system.binance = binance  # report 커맨드용
@@ -271,11 +273,13 @@ class KairosSimple:
             reb_cfg, crypto_weights=self._effective_weights(notes)
         )
         snap = self.portfolio.get_snapshot()
-        try:
-            # 월간 수익률 데이터 축적 — 기록 실패가 거래를 막으면 안 됨
-            self.portfolio.record_snapshot(snap)
-        except Exception as e:
-            logger.error(f"스냅샷 기록 실패 (체크는 계속): {e}")
+        if not dry_run:
+            # dry-run이 스냅샷을 남기면 전일 대비·30일 수익률 기준선 오염
+            try:
+                # 월간 수익률 데이터 축적 — 기록 실패가 거래를 막으면 안 됨
+                self.portfolio.record_snapshot(snap)
+            except Exception as e:
+                logger.error(f"스냅샷 기록 실패 (체크는 계속): {e}")
         orders = plan_rebalance(reb_cfg, snap.holdings_krw, snap.krw_balance)
         if not orders:
             logger.info(f"밴드 내 (크립토 {snap.crypto_ratio:.1%}) — 거래 없음")
@@ -342,10 +346,12 @@ class KairosSimple:
         snap = self.portfolio.get_snapshot()
         reporter = Reporter(self.binance, self.alerts)
         # 일일 스냅샷 이력 기반 30일 총자산 변화율 (입출금 포함 단순 변화)
-        portfolio_return = self.portfolio.get_value_change_30d(snap.total_value_krw)
-        if portfolio_return is not None:
+        change = self.portfolio.get_value_change_30d(snap.total_value_krw)
+        if change is not None:
+            portfolio_return, window_days = change
             return reporter.monthly_report(
-                portfolio_return, snap.total_value_krw, snap.crypto_ratio
+                portfolio_return, snap.total_value_krw, snap.crypto_ratio,
+                window_days=window_days,
             )
         benchmark = reporter.btc_benchmark_return(days=30)
         report = {
@@ -377,11 +383,15 @@ class KairosSimple:
                      price_changes=None, notes=None) -> Dict:
         executed, rejected = 0, []
         executed_reqs = []
+        # KRW 러닝 잔고 — 배치 시작 스냅샷으로 모든 주문을 검증하면
+        # (a) 여러 매수가 합산 후 KRW 하한을 뚫고, (b) 매도 대금으로
+        # 승인돼야 할 매수가 거부된다(한쪽 다리 리밸런싱). 체결마다 갱신.
+        krw_running = snap.krw_balance
         # 매도 먼저 실행해 KRW 확보 후 매수 (하락장 리밸런싱 매수 자금)
         for req in sorted(requests, key=lambda r: r.side != "sell"):
             ctx = PortfolioContext(
                 total_value_krw=snap.total_value_krw,
-                krw_balance=snap.krw_balance,
+                krw_balance=krw_running,
                 daily_traded_krw=self._daily_traded_krw,
                 price_change_24h=price_changes or {},
             )
@@ -404,6 +414,7 @@ class KairosSimple:
                     OrderRequest(req.asset, req.side, filled, req.origin)
                 )
                 self._daily_traded_krw += filled
+                krw_running += filled if req.side == "sell" else -filled
                 # 주문은 이미 체결됨 — 기록 실패가 나머지 주문 실행을 막으면 안 됨
                 try:
                     self.portfolio.record_trade(
@@ -478,6 +489,40 @@ class KairosSimple:
         return {"executed": 0, "rejected": [], "halted": True, "error": str(error)}
 
 
+def _crash_alert_best_effort(command: str, config_path: str, error) -> None:
+    """조립 단계(설정 파싱·DB·클라이언트 생성) 실패도 Slack에 남긴다.
+
+    _guarded는 run_* 안쪽만 덮는다 — 여기서 죽으면 briefing 하트비트까지
+    조용히 끊겨 fail-loud 계약이 깨진다. AlertSystem 조립조차 실패하면
+    SLACK_WEBHOOK_URL 환경변수로 직접 POST한다."""
+    import os
+
+    msg = f"'{command}' 실행 불가 — 시스템 조립 단계 오류: {error}"
+    try:
+        from src.monitoring.alert_system import AlertSystem
+        from src.utils.config_loader import ConfigLoader
+
+        AlertSystem(ConfigLoader(config_path)).send_error_alert(
+            "시스템 시작 실패", msg
+        )
+        return
+    except Exception as e:
+        logger.warning(f"AlertSystem 경유 크래시 알림 실패, webhook 직접 시도: {e}")
+    try:
+        import requests
+
+        webhook = os.environ.get("SLACK_WEBHOOK_URL")
+        if webhook:
+            requests.post(
+                webhook, json={"text": f"🚨 KAIROS 시스템 시작 실패\n{msg}"},
+                timeout=10,
+            )
+        else:
+            logger.error("SLACK_WEBHOOK_URL 미설정 — 크래시 알림 발송 불가")
+    except Exception as e:
+        logger.error(f"크래시 알림 발송 실패: {e}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="KAIROS-Simple 장기 역발상 매집")
     parser.add_argument(
@@ -488,17 +533,23 @@ def main() -> int:
     parser.add_argument("--config", default="config/config.yaml")
     args = parser.parse_args()
 
-    system = KairosSimple.from_yaml(args.config)
-    if args.command == "weekly-dca":
-        result = system.run_weekly_dca(dry_run=args.dry_run)
-    elif args.command == "daily-check":
-        result = system.run_daily_check(dry_run=args.dry_run)
-    elif args.command == "briefing":
-        result = system.run_daily_briefing()
-    elif args.command == "report":
-        result = system.run_monthly_report()
-    else:
-        result = system.get_status()
+    try:
+        system = KairosSimple.from_yaml(args.config)
+        if args.command == "weekly-dca":
+            result = system.run_weekly_dca(dry_run=args.dry_run)
+        elif args.command == "daily-check":
+            result = system.run_daily_check(dry_run=args.dry_run)
+        elif args.command == "briefing":
+            result = system.run_daily_briefing()
+        elif args.command == "report":
+            result = system.run_monthly_report()
+        else:
+            result = system.get_status()
+    except Exception as e:
+        # run_*는 자체 가드가 있다 — 여기 오는 건 조립·status 단계 예외
+        logger.exception(f"시스템 조립/실행 실패: {e}")
+        _crash_alert_best_effort(args.command, args.config, e)
+        return 1
     print(result)
     return 1 if result.get("halted") else 0
 

--- a/scripts/backtest_longterm.py
+++ b/scripts/backtest_longterm.py
@@ -126,13 +126,20 @@ def run_backtest(
         values.append(krw + btc_qty * price)
 
     series = pd.Series(values)
-    weekly_ret = series.pct_change().dropna()
+    # 시간가중 수익률: 주간 적립(외부 입금)은 수익이 아니다 —
+    # r_t = (V_t − 입금) / V_{t−1} − 1. 원시 가치 시계열로 계산하면
+    # 입금이 수익률로 잡혀 Sharpe가 부풀고 MDD가 완충된다.
+    weekly_ret = ((series - WEEKLY_BASE_DCA) / series.shift(1) - 1.0).dropna()
     sharpe = (
         float(weekly_ret.mean() / weekly_ret.std() * np.sqrt(52))
         if len(weekly_ret) > 1 and weekly_ret.std() > 0
         else 0.0
     )
-    drawdown = float((series / series.cummax() - 1).min())
+    twr_index = (1.0 + weekly_ret).cumprod()
+    drawdown = (
+        float((twr_index / twr_index.cummax() - 1).min())
+        if len(twr_index) > 0 else 0.0
+    )
     return BacktestResult(
         final_value=float(series.iloc[-1]), total_buy_krw=float(buys),
         total_sell_krw=float(sells), total_trades=int(trades),

--- a/src/data/market_data.py
+++ b/src/data/market_data.py
@@ -68,13 +68,26 @@ class MarketDataService:
         return prices
 
     def get_price_change_24h(self, assets: List[str]) -> Dict[str, float]:
+        """현재가 대비 24시간 전 가격 변동률 — 크래시 가드·FOMO 가드 입력.
+
+        일봉 iloc[-2] 방식은 'UTC 자정 이후 변동'이라 09:10 KST(=00:10 UTC)
+        크론에서는 항상 ≈0%가 되어 두 가드가 결코 발동하지 않았다.
+        시간봉으로 진짜 롤링 24시간 창을 계산한다."""
+        from datetime import datetime, timedelta
+
         changes = {}
         for asset in assets:
-            daily = self.binance.get_historical_klines(
-                symbol=f"{asset}USDT", interval="1d", limit=2
+            hourly = self.binance.get_historical_klines(
+                symbol=f"{asset}USDT", interval="1h",
+                start_date=datetime.now() - timedelta(hours=26),
             )
-            if daily is None or len(daily) < 2:
-                raise DataUnavailableError(f"{asset} 일봉 조회 실패")
-            prev, last = float(daily["Close"].iloc[-2]), float(daily["Close"].iloc[-1])
-            changes[asset] = last / prev - 1.0
+            if (hourly is None or len(hourly) < 25
+                    or "Close" not in getattr(hourly, "columns", [])):
+                raise DataUnavailableError(f"{asset} 시간봉 24시간치 조회 실패")
+            # 마지막 행은 진행 중 캔들(현재가), -25번째 종가가 약 24시간 전
+            ref = float(hourly["Close"].iloc[-25])
+            last = float(hourly["Close"].iloc[-1])
+            if ref <= 0:
+                raise DataUnavailableError(f"{asset} 시간봉 가격 이상: {ref}")
+            changes[asset] = last / ref - 1.0
         return changes

--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -31,13 +31,15 @@ class ExecutionReport:
 class OrderExecutor:
     def __init__(self, coinone_client, twap_slice_krw: float,
                  max_retries: int = 3, retry_wait: float = 2.0,
-                 fill_timeout: float = 45.0, poll_interval: float = 3.0):
+                 fill_timeout: float = 45.0, poll_interval: float = 3.0,
+                 slippage_cap: float = SLIPPAGE_CAP):
         self.coinone = coinone_client
         self.twap_slice_krw = twap_slice_krw
         self.max_retries = max_retries
         self.retry_wait = retry_wait
         self.fill_timeout = fill_timeout
         self.poll_interval = poll_interval
+        self.slippage_cap = slippage_cap
 
     def execute(self, order: OrderRequest) -> ExecutionReport:
         report = ExecutionReport(request=order, success=True)
@@ -49,7 +51,7 @@ class OrderExecutor:
                 logger.error(f"{order.asset} {order.side} 슬라이스 실패: {err}")
                 break  # 부분 체결 상태로 중단 — filled_krw로 잔량 파악
             report.order_ids.append(order_id)
-            fraction = self._await_fill(order_id, ordered_qty)
+            fraction = self._await_fill(order_id, ordered_qty, order.asset)
             report.filled_krw += slice_krw * fraction
             if fraction < 1.0 - 1e-9:
                 # 미체결 잔량은 이미 취소됨 — 가격이 지정가 밖으로 움직인
@@ -63,14 +65,18 @@ class OrderExecutor:
         return report
 
     # ------------------------------------------------------------ 체결 확인
-    def _await_fill(self, order_id: str, ordered_qty: float) -> float:
-        """fill_timeout 내 체결을 폴링, 타임아웃 시 잔량 취소 → 체결 비율."""
+    def _await_fill(self, order_id: str, ordered_qty: float, asset: str) -> float:
+        """fill_timeout 내 체결을 폴링, 타임아웃 시 잔량 취소 → 체결 비율.
+
+        order/info·order/cancel은 마켓(quote/target_currency) 지정이 필수라
+        자산을 함께 전달한다 — 누락 시 조회·취소가 실패해 체결분이 0으로
+        집계되고 미체결 주문이 호가창에 방치된다."""
         deadline = time.monotonic() + self.fill_timeout
         fraction = 0.0
         while True:
             try:
                 fraction = self._fill_fraction(
-                    self.coinone.get_order_status(order_id), ordered_qty,
+                    self.coinone.get_order_status(order_id, asset), ordered_qty,
                     assume_filled_on_not_found=True,
                 )
             except Exception as e:
@@ -81,14 +87,14 @@ class OrderExecutor:
                 break
             time.sleep(self.poll_interval)
         try:
-            self.coinone.cancel_order(order_id)
+            self.coinone.cancel_order(order_id, asset)
         except Exception as e:
             logger.error(f"미체결 취소 실패: {order_id} — {e}")
         try:
             # 취소 직전 체결됐을 수 있으므로 최종 상태 재확인.
             # 취소 후 not_found는 체결로 단정할 수 없어 마지막 관측값 유지.
             return self._fill_fraction(
-                self.coinone.get_order_status(order_id), ordered_qty,
+                self.coinone.get_order_status(order_id, asset), ordered_qty,
                 assume_filled_on_not_found=False, default=fraction,
             )
         except Exception:
@@ -129,7 +135,8 @@ class OrderExecutor:
                 if not price or price <= 0:
                     raise ValueError(f"{order.asset} 현재가 조회 실패: {price}")
                 limit = price * (
-                    1 + SLIPPAGE_CAP if order.side == "buy" else 1 - SLIPPAGE_CAP
+                    1 + self.slippage_cap if order.side == "buy"
+                    else 1 - self.slippage_cap
                 )
                 # 코인원 호가 단위 정렬 (오류 310 방지):
                 # 매수는 내림(캡 준수), 매도는 올림(하한 준수)
@@ -148,6 +155,12 @@ class OrderExecutor:
                 )
                 if isinstance(result, dict) and result.get("success"):
                     return True, str(result.get("order_id", "")), qty, ""
+                if isinstance(result, dict) and result.get("ambiguous"):
+                    # 주문이 거래소에 도달했는지 알 수 없는 실패 — 재제출하면
+                    # 이중 주문이 될 수 있다. fail-safe로 즉시 중단.
+                    last_err = (f"주문 접수 불확실 (네트워크 오류) — 이중 주문 "
+                                f"방지 위해 재시도 중단: {result.get('error')}")
+                    return False, "", 0.0, last_err
                 last_err = f"API 오류 응답: {result}"
             except Exception as e:
                 last_err = str(e)

--- a/src/monitoring/alert_system.py
+++ b/src/monitoring/alert_system.py
@@ -68,9 +68,12 @@ class AlertSystem:
         
         results = {}
         
-        # 채널 목록 결정
+        # 채널 목록 결정 — alert_type은 "system_info"·"daily_summary" 등
+        # 세부 유형이 오므로, 레벨 설정(error/warning/info) 조회는 error·
+        # warning 외 전부 info로 정규화한다 (config의 info: 채널이 죽는 것 방지)
         if channels is None:
-            channels = self.alert_levels.get(alert_type, ["slack"])
+            level_key = alert_type if alert_type in ("error", "warning") else "info"
+            channels = self.alert_levels.get(level_key, ["slack"])
         
         # 각 채널로 알림 발송
         for channel in channels:
@@ -323,14 +326,16 @@ class AlertSystem:
             mentions_config = self.slack_config.get("mentions", {})
             logger.info(f"[멘션] 설정 확인 - alert_type: {alert_type}")
             
-            # 특정 알림 유형별 멘션 확인
+            # 특정 알림 유형별 멘션 확인 — 반드시 복사본 사용:
+            # 설정 리스트를 그대로 참조하면 아래 append가 원본을 오염시켜
+            # 두 번째 에러 알림부터 '@here @here …'로 누적된다
             by_alert_type = mentions_config.get("by_alert_type", {})
-            mention_users = by_alert_type.get(alert_type, [])
+            mention_users = list(by_alert_type.get(alert_type, []))
             logger.info(f"[멘션] 알림 유형별 사용자: {mention_users}")
-            
+
             # 기본 멘션 사용자가 설정된 경우 (특정 유형별 설정이 없을 때만)
             if not mention_users:
-                mention_users = mentions_config.get("default_users", [])
+                mention_users = list(mentions_config.get("default_users", []))
                 logger.info(f"[멘션] 기본 사용자 사용: {mention_users}")
             
             # 전체 채널 멘션이 필요한 유형인지 확인
@@ -340,7 +345,7 @@ class AlertSystem:
             if alert_type == "error" or alert_type == "system_error":
                 # error 알림에 대한 특별 처리: 기본 사용자 + @here 추가
                 if not mention_users:  # 설정된 사용자가 없다면 기본값 사용
-                    mention_users = mentions_config.get("default_users", [])
+                    mention_users = list(mentions_config.get("default_users", []))
                 mention_users.append("@here")  # 민감한 알림이므로 @here 추가
                 logger.info(f"[멘션] 에러 알림 - @here 자동 추가: {mention_users}")
             elif alert_type in channel_mention_types:

--- a/src/monitoring/performance_tracker.py
+++ b/src/monitoring/performance_tracker.py
@@ -132,7 +132,11 @@ class PerformanceTracker:
         Returns:
             일간 수익률 배열
         """
-        values = np.array(portfolio_values)
+        # 과거 저장 버그로 0이 섞인 스냅샷 방어 — 0 분모는 inf를 만들어
+        # Sharpe·변동성·MDD 전부를 오염시킨다
+        values = np.array([v for v in portfolio_values if v and v > 0])
+        if len(values) < 2:
+            return np.array([])
         returns = (values[1:] - values[:-1]) / values[:-1]
         return returns
     
@@ -429,12 +433,16 @@ class PerformanceTracker:
                 "avg_trade_size": 0.0
             }
         
+        # trade_history 실제 컬럼: side/amount_krw/fee_krw (status·fee·amount
+        # 아님 — 잘못된 키를 읽으면 수수료·평균 거래액이 항상 0이 된다).
+        # 기록되는 거래는 체결분뿐이므로 전 행이 성공 거래다.
         total_trades = len(trade_history)
-        successful_trades = len([t for t in trade_history if t.get("status") == "filled"])
-        success_rate = successful_trades / total_trades if total_trades > 0 else 0.0
-        
-        total_fees = sum(t.get("fee", 0) for t in trade_history)
-        trade_sizes = [t.get("amount", 0) for t in trade_history if t.get("amount")]
+        successful_trades = total_trades
+        success_rate = 1.0 if total_trades > 0 else 0.0
+
+        total_fees = sum(t.get("fee_krw") or 0 for t in trade_history)
+        trade_sizes = [t.get("amount_krw", 0) for t in trade_history
+                       if t.get("amount_krw")]
         avg_trade_size = np.mean(trade_sizes) if trade_sizes else 0.0
         
         return {
@@ -458,19 +466,25 @@ class PerformanceTracker:
         total_value = portfolio_snapshot.get("total_value_krw", 0)
         if total_value <= 0:
             return None
-        
+
+        # 자산 상세는 portfolio_detail JSON에 저장된다 — 자산별 컬럼
+        # (krw_balance, btc_value_krw…)은 현 스키마에 존재하지 않는다
+        import json as _json
+
+        try:
+            detail = portfolio_snapshot.get("portfolio_detail")
+            assets = (_json.loads(detail) if isinstance(detail, str)
+                      else detail or {}).get("assets", {})
+        except (ValueError, TypeError):
+            assets = {}
+
         allocation = {}
-        
-        # 각 자산의 비중 계산
-        for asset in ["KRW", "BTC", "ETH", "XRP", "SOL"]:
-            if asset == "KRW":
-                value = portfolio_snapshot.get("krw_balance", 0)
-            else:
-                value = portfolio_snapshot.get(f"{asset.lower()}_value_krw", 0)
-            
-            allocation[asset] = value / total_value if total_value > 0 else 0.0
-        
-        return allocation
+        for asset, data in assets.items():
+            value = (data.get("value_krw", 0)
+                     if isinstance(data, dict) else float(data or 0))
+            allocation[asset] = value / total_value
+
+        return allocation or None
     
     def _assess_risk_level(self, metrics: PerformanceMetrics) -> str:
         """

--- a/src/portfolio/portfolio.py
+++ b/src/portfolio/portfolio.py
@@ -62,17 +62,26 @@ class PortfolioService:
     def get_value_change_30d(self, current_total_krw: float):
         """최근 30일 총자산 변화율 (입출금 포함 단순 변화).
 
-        스냅샷 이력이 없으면 None — 데이터 없이 수익률을 주장하지 않는다.
+        (변화율, 관측 창 일수) 튜플을 반환 — 5일치 데이터로 계산한 수익률을
+        30일 벤치마크와 비교하는 사과-오렌지 비교를 막으려면 호출부가
+        실제 창을 알아야 한다. 오늘 이전 스냅샷이 없으면 None — 당일
+        스냅샷을 기준선으로 잡으면 수익률이 항상 ≈0%가 된다.
         """
-        history = self.db.get_portfolio_history(30)
+        today = datetime.now().strftime("%Y-%m-%d")
         baseline = next(
-            (float(row["total_value_krw"]) for row in history
-             if float(row.get("total_value_krw", 0)) > 0),
+            ((float(row["total_value_krw"]), str(row["snapshot_date"])[:10])
+             for row in self.db.get_portfolio_history(30)
+             if float(row.get("total_value_krw") or 0) > 0
+             and str(row.get("snapshot_date", ""))[:10] < today),
             None,
         )
         if baseline is None:
             return None
-        return current_total_krw / baseline - 1.0
+        value, date_str = baseline
+        window_days = (
+            datetime.now() - datetime.strptime(date_str, "%Y-%m-%d")
+        ).days
+        return current_total_krw / value - 1.0, max(window_days, 1)
 
     def get_previous_total_krw(self):
         """오늘 이전 가장 최근 스냅샷의 총자산 — 데일리 브리핑 전일 대비용.

--- a/src/report/reporter.py
+++ b/src/report/reporter.py
@@ -22,19 +22,25 @@ class Reporter:
         return last / first - 1.0
 
     def monthly_report(
-        self, portfolio_return: float, total_value_krw: float, crypto_ratio: float
+        self, portfolio_return: float, total_value_krw: float,
+        crypto_ratio: float, window_days: int = 30,
     ) -> Dict:
-        benchmark = self.btc_benchmark_return(days=30)
+        """window_days: 포트폴리오 수익률의 실제 관측 창 — 벤치마크도 같은
+        창으로 계산해야 초과수익 비교가 성립한다 (배포 초기 5일치 수익률을
+        30일 BTC와 비교하는 오류 방지)."""
+        benchmark = self.btc_benchmark_return(days=window_days)
         report = {
             "portfolio_return": portfolio_return,
             "btc_benchmark_return": benchmark,
             "excess_return": portfolio_return - benchmark,
             "total_value_krw": total_value_krw,
             "crypto_ratio": crypto_ratio,
+            "window_days": window_days,
         }
         self.alerts.send_info_alert(
             "월간 성과 리포트",
-            f"수익률 {portfolio_return:+.1%} / BTC {benchmark:+.1%} "
+            f"수익률({window_days}일) {portfolio_return:+.1%} / "
+            f"BTC {benchmark:+.1%} "
             f"(초과 {report['excess_return']:+.1%}) | "
             f"총자산 {total_value_krw:,.0f} KRW | 크립토 {crypto_ratio:.0%}",
         )

--- a/src/strategy/rebalance.py
+++ b/src/strategy/rebalance.py
@@ -45,8 +45,16 @@ def plan_rebalance(
     asset_breach = False
     if crypto_value > 0:
         for asset, target_w in config.crypto_weights.items():
-            actual_w = holdings_krw.get(asset, 0.0) / crypto_value
-            if target_w > 0 and abs(actual_w / target_w - 1.0) > config.relative_band:
+            actual = holdings_krw.get(asset, 0.0)
+            if target_w <= 0:
+                # 완전 편출(목표 0) 자산: 잔여 포지션 자체가 트리거 —
+                # 다른 이탈을 기다리며 무기한 방치되면 안 된다
+                if actual >= config.min_trade_krw:
+                    asset_breach = True
+                    break
+                continue
+            actual_w = actual / crypto_value
+            if abs(actual_w / target_w - 1.0) > config.relative_band:
                 asset_breach = True
                 break
 

--- a/src/trading/coinone_client.py
+++ b/src/trading/coinone_client.py
@@ -22,6 +22,16 @@ from ..utils.constants import (
 )
 
 
+def _format_decimal(value: float) -> str:
+    """지수 표기 없는 고정 소수점 문자열 (코인원 API 파라미터용).
+
+    int() 절삭은 1,000 KRW 미만 자산의 소수 호가 단위(0.5 등)를 파괴해
+    슬리피지 캡을 위반하고, str(float)는 1e-4 미만 수량을 '6.25e-05'로
+    보내 파서에 따라 주문이 거부될 수 있다."""
+    text = f"{float(value):.8f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
 class CoinoneClient:
     """
     코인원 거래소 API 클라이언트
@@ -31,15 +41,19 @@ class CoinoneClient:
     - Private API: POST 방식, v2.1
     """
     
-    def __init__(self, api_key: str, secret_key: str, sandbox: bool = False):
+    def __init__(self, api_key: str, secret_key: str, sandbox: bool = False,
+                 timeout: float = API_REQUEST_TIMEOUT):
         """
         Args:
             api_key: 코인원 API 키
             secret_key: 코인원 시크릿 키
             sandbox: 테스트 환경 사용 여부 (현재 지원하지 않음)
+            timeout: HTTP 요청 타임아웃(초) — 없으면 응답 유실 시 크론이
+                무한 대기한다
         """
         self.api_key = api_key
         self.secret_key = secret_key
+        self.timeout = float(timeout)
         
         # 코인원 실제 API 엔드포인트 사용
         self.base_url = "https://api.coinone.co.kr"
@@ -115,7 +129,8 @@ class CoinoneClient:
             # Public API는 인증 헤더 없이 GET 요청
             headers = {"Content-Type": "application/json"}
             try:
-                response = requests.get(url, headers=headers, params=params)
+                response = requests.get(url, headers=headers, params=params,
+                                        timeout=self.timeout)
                 response.raise_for_status()
                 return response.json()
             except requests.exceptions.RequestException as e:
@@ -128,7 +143,8 @@ class CoinoneClient:
             
             headers, body = self._create_signature(params)
             try:
-                response = requests.post(url, headers=headers, json=body)
+                response = requests.post(url, headers=headers, json=body,
+                                         timeout=self.timeout)
                 response.raise_for_status()
                 return response.json()
             except requests.exceptions.RequestException as e:
@@ -404,8 +420,8 @@ class CoinoneClient:
                     "quote_currency": "KRW",
                     "target_currency": currency.upper(),
                     "type": "LIMIT",
-                    "price": str(int(price)),
-                    "qty": str(amount),
+                    "price": _format_decimal(price),
+                    "qty": _format_decimal(amount),
                     "post_only": False
                 }
                 logger.info(f"지정가 주문: {side} {amount} {currency} @ {price}")
@@ -507,8 +523,23 @@ class CoinoneClient:
                         "qty": str(quantity)
                     }
             
-            response = self._make_request("POST", endpoint, params, is_public=False)
-            
+            try:
+                response = self._make_request("POST", endpoint, params, is_public=False)
+            except requests.exceptions.HTTPError as e:
+                status = getattr(getattr(e, "response", None), "status_code", None)
+                if status is not None and status < 500:
+                    # 4xx: 서버가 주문을 거부 — 미접수 확정, 재시도 안전
+                    logger.error(f"주문 거부 (HTTP {status}): {e}")
+                    return {"success": False, "error": str(e)}
+                logger.error(f"주문 접수 여부 불확실 (HTTP {status}): {e}")
+                return {"success": False, "ambiguous": True, "error": str(e)}
+            except requests.exceptions.RequestException as e:
+                # 타임아웃·연결 유실: POST가 거래소에 도달했는지 알 수 없다.
+                # 일반 실패로 취급해 재시도하면 이중 주문 위험 — ambiguous로
+                # 표시해 호출부가 재시도를 중단하게 한다.
+                logger.error(f"주문 접수 여부 불확실 (네트워크): {e}")
+                return {"success": False, "ambiguous": True, "error": str(e)}
+
             if response.get("result") == "success":
                 order_id = response.get("order_id", "unknown")
                 logger.info(f"✅ 주문 성공: {side} {amount} {currency} (주문ID: {order_id})")
@@ -518,7 +549,7 @@ class CoinoneClient:
                 error_msg = response.get("error_msg", "unknown error")
                 logger.error(f"❌ 주문 실패: {response}")
                 return {"success": False, "error_code": error_code, "error_msg": error_msg, "response": response}
-                
+
         except Exception as e:
             logger.error(f"주문 실행 실패: {e}")
             return {"success": False, "error": str(e)}
@@ -704,20 +735,26 @@ class CoinoneClient:
             logger.error(f"주문 크기 조정 실패: {e}")
             return amount
 
-    def get_order_status(self, order_id: str) -> Dict:
+    def get_order_status(self, order_id: str, currency: str) -> Dict:
         """
         주문 상태 조회 (Private API v2.1)
-        
+
         Args:
             order_id: 주문 ID
-            
+            currency: 대상 통화 (예: "BTC") — v2.1 order/info는
+                quote_currency/target_currency가 필수라 누락 시 조회 실패
+
         Returns:
             주문 상태 정보
         """
         try:
             # Private API v2.1: 특정 주문 정보 조회
-            params = {"order_id": order_id}
-            
+            params = {
+                "order_id": order_id,
+                "quote_currency": "KRW",
+                "target_currency": currency.upper(),
+            }
+
             response = self._make_request("POST", "/v2.1/order/info", params, is_public=False)
             logger.debug(f"주문 상태 조회: {order_id}")
             return response
@@ -735,20 +772,26 @@ class CoinoneClient:
                 logger.error(f"주문 상태 조회 실패: {e}")
                 raise
     
-    def cancel_order(self, order_id: str) -> Dict:
+    def cancel_order(self, order_id: str, currency: str) -> Dict:
         """
         주문 취소 (Private API v2.1)
-        
+
         Args:
             order_id: 주문 ID
-            
+            currency: 대상 통화 (예: "BTC") — v2.1 order/cancel은
+                quote_currency/target_currency가 필수라 누락 시 취소 실패
+
         Returns:
             주문 취소 결과
         """
         try:
             # Private API v2.1: 개별 주문 취소
-            params = {"order_id": order_id}
-            
+            params = {
+                "order_id": order_id,
+                "quote_currency": "KRW",
+                "target_currency": currency.upper(),
+            }
+
             response = self._make_request("POST", "/v2.1/order/cancel", params, is_public=False)
             
             if response.get("result") == "success":

--- a/src/trading/rate_limited_client.py
+++ b/src/trading/rate_limited_client.py
@@ -2,12 +2,25 @@
 Rate Limited Client
 CoinoneClient에 API 속도 제한을 적용하는 래퍼 클래스입니다.
 기존 코드 변경 없이 속도 제한 기능을 추가할 수 있습니다.
+
+주의: API 메서드를 클래스에 명시적으로 정의하면 __getattr__이 호출되지
+않아 래핑이 무력화된다 (과거 버그). 모든 프록시는 __getattr__로만 한다.
 """
 import asyncio
-from typing import Any, Dict
 from loguru import logger
 from .coinone_client import CoinoneClient
 from ..core.system_coordinator import get_system_coordinator
+
+# 실제 네트워크 요청을 하는 메서드들 — 속도 제한 적용 대상
+API_METHODS = {
+    'get_account_info', 'get_balances', 'get_portfolio_value',
+    'place_order', 'cancel_order', 'get_order_status',
+    'get_latest_price', 'get_orderbook', 'get_ticker',
+    'get_orders_history', 'get_order_info', 'get_user_info',
+    'submit_market_order', 'submit_limit_order'
+}
+
+
 class RateLimitedCoinoneClient:
     """
     속도 제한이 적용된 CoinoneClient 래퍼
@@ -22,81 +35,46 @@ class RateLimitedCoinoneClient:
         self.original_client = original_client
         self.system_coordinator = get_system_coordinator()
         logger.info("RateLimitedCoinoneClient 초기화 완료")
+
     def __getattr__(self, name):
         """
         원본 클라이언트의 속성/메서드에 대한 프록시
         API 호출 메서드는 속도 제한을 적용하고, 나머지는 그대로 전달
         """
         attr = getattr(self.original_client, name)
-        # 메서드인 경우 속도 제한 래핑
-        if callable(attr):
-            # API 호출 메서드들 (실제 네트워크 요청을 하는 메서드들)
-            api_methods = {
-                'get_account_info', 'get_balances', 'get_portfolio_value',
-                'place_order', 'cancel_order', 'get_order_status',
-                'get_latest_price', 'get_orderbook', 'get_ticker',
-                'get_orders_history', 'get_order_info', 'get_user_info',
-                'submit_market_order', 'submit_limit_order'
-            }
-            if name in api_methods:
-                return self._wrap_api_method(attr, name)
+        if callable(attr) and name in API_METHODS:
+            return self._wrap_api_method(attr, name)
         return attr
+
     def _wrap_api_method(self, method, method_name: str):
-        """API 메서드를 속도 제한 래퍼로 감싸기"""
+        """API 메서드를 속도 제한 래퍼로 감싸기.
+
+        원본 메서드는 정확히 1회만 호출한다 — 실패 시 재호출 폴백은
+        주문 같은 부작용 있는 호출을 이중 실행할 수 있어 금지."""
         def wrapped_method(*args, **kwargs):
-            try:
-                # 동기 방식으로 속도 제한 적용
-                loop = None
-                try:
-                    loop = asyncio.get_running_loop()
-                except RuntimeError:
-                    # 이벤트 루프가 없으면 새로 생성
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                # 비동기 컨텍스트에서 실행
-                if loop.is_running():
-                    # 이미 실행 중인 루프에서는 동기적으로 처리
-                    logger.debug(f"API 호출: {method_name} (동기 모드)")
-                    return method(*args, **kwargs)
-                else:
-                    # 새 루프에서 비동기 처리
-                    return loop.run_until_complete(
-                        self._async_api_call(method, method_name, *args, **kwargs)
-                    )
-            except Exception as e:
-                logger.error(f"속도 제한 API 호출 실패 ({method_name}): {e}")
-                # 실패 시 원본 메서드 직접 호출
-                return method(*args, **kwargs)
+            self._throttle(method_name)
+            return method(*args, **kwargs)
         return wrapped_method
-    async def _async_api_call(self, method, method_name: str, *args, **kwargs):
-        """비동기 API 호출 (속도 제한 적용)"""
-        logger.debug(f"API 호출 대기 중: {method_name}")
-        # 속도 제한 적용
-        await self.system_coordinator.api_rate_limiter.acquire()
-        logger.debug(f"API 호출 실행: {method_name}")
-        return method(*args, **kwargs)
-    # 주요 메서드들을 명시적으로 정의 (IDE 지원 및 타입 힌트)
-    def get_account_info(self) -> Dict[str, Any]:
-        """계정 정보 조회"""
-        return self.original_client.get_account_info()
-    def get_balances(self) -> Dict[str, float]:
-        """잔고 조회"""
-        return self.original_client.get_balances()
-    def get_portfolio_value(self) -> Dict[str, Any]:
-        """포트폴리오 가치 조회"""
-        return self.original_client.get_portfolio_value()
-    def place_order(self, *args, **kwargs) -> Dict[str, Any]:
-        """주문 실행"""
-        return self.original_client.place_order(*args, **kwargs)
-    def get_latest_price(self, currency: str) -> float:
-        """최신 가격 조회"""
-        return self.original_client.get_latest_price(currency)
-    def cancel_order(self, order_id: str) -> Dict[str, Any]:
-        """주문 취소"""
-        return self.original_client.cancel_order(order_id)
-    def get_order_status(self, order_id: str) -> Dict[str, Any]:
-        """주문 상태 조회"""
-        return self.original_client.get_order_status(order_id)
+
+    def _throttle(self, method_name: str) -> None:
+        """속도 제한 획득 — 리미터 문제가 실제 호출을 막으면 안 됨."""
+        try:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+            if loop.is_running():
+                # 실행 중인 루프 안에서는 동기 대기 불가 — 제한 없이 통과
+                logger.debug(f"API 호출 (루프 내 동기 모드): {method_name}")
+                return
+            loop.run_until_complete(
+                self.system_coordinator.api_rate_limiter.acquire()
+            )
+        except Exception as e:
+            logger.warning(f"속도 제한 획득 실패 (호출은 계속): {method_name} — {e}")
+
+
 def create_rate_limited_client(original_client: CoinoneClient) -> RateLimitedCoinoneClient:
     """
     기존 CoinoneClient를 속도 제한 적용 클라이언트로 래핑

--- a/src/utils/database_manager.py
+++ b/src/utils/database_manager.py
@@ -116,11 +116,21 @@ class DatabaseManager:
                         market_season TEXT,
                         target_allocation TEXT,
                         twap_orders_detail TEXT,
+                        result_data TEXT,
                         created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                         updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
                         completed_at TEXT
                     )
                 """)
+
+                # 구버전 DB 마이그레이션: result_data 컬럼이 없으면 상태
+                # 업데이트(UPDATE ... SET result_data)가 조용히 실패한다
+                cursor.execute("PRAGMA table_info(twap_executions)")
+                twap_cols = {row[1] for row in cursor.fetchall()}
+                if "result_data" not in twap_cols:
+                    cursor.execute(
+                        "ALTER TABLE twap_executions ADD COLUMN result_data TEXT"
+                    )
 
                 # 시장 분석 테이블
                 cursor.execute("""
@@ -149,6 +159,20 @@ class DatabaseManager:
                         created_at TEXT DEFAULT CURRENT_TIMESTAMP
                     )
                 """)
+
+                # 구버전 DB 마이그레이션: 과거 배포본의 wide 스키마
+                # (자산별 컬럼, portfolio_detail 없음)에도 현재 INSERT가
+                # 동작하도록 누락 컬럼 추가
+                cursor.execute("PRAGMA table_info(portfolio_snapshots)")
+                snapshot_cols = {row[1] for row in cursor.fetchall()}
+                for col, col_type in {
+                    "total_value_krw": "REAL DEFAULT 0",
+                    "portfolio_detail": "TEXT",
+                }.items():
+                    if col not in snapshot_cols:
+                        cursor.execute(
+                            f"ALTER TABLE portfolio_snapshots ADD COLUMN {col} {col_type}"
+                        )
 
                 # 거래 기록 테이블
                 cursor.execute("""
@@ -463,30 +487,15 @@ class DatabaseManager:
         try:
             with self.get_connection() as conn:
                 cursor = conn.cursor()
-                
-                assets = portfolio_data.get("assets", {})
-                
-                # 각 자산의 정보 추출
-                def get_asset_info(asset_name):
-                    asset_data = assets.get(asset_name, {})
-                    if isinstance(asset_data, dict):
-                        return asset_data.get("balance", 0), asset_data.get("value_krw", 0)
-                    else:
-                        return asset_data, 0
-                
-                btc_balance, btc_value = get_asset_info("BTC")
-                eth_balance, eth_value = get_asset_info("ETH")
-                xrp_balance, xrp_value = get_asset_info("XRP")
-                sol_balance, sol_value = get_asset_info("SOL")
-                krw_balance = assets.get("KRW", 0)
-                
+
+                # INSERT는 반드시 _initialize_database의 DDL 컬럼과 일치해야
+                # 한다 — 과거 자산별 컬럼(krw_balance, btc_balance…)에 쓰던
+                # INSERT가 좁은 스키마와 어긋나 운영에서 스냅샷 저장이 전부
+                # 조용히 실패했다. 자산 상세는 portfolio_detail JSON에 보존.
                 cursor.execute("""
                     INSERT INTO portfolio_snapshots (
-                        snapshot_date, total_value_krw, krw_balance,
-                        btc_balance, btc_value_krw, eth_balance, eth_value_krw,
-                        xrp_balance, xrp_value_krw, sol_balance, sol_value_krw,
-                        portfolio_data
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        snapshot_date, total_value_krw, portfolio_detail
+                    ) VALUES (?, ?, ?)
                 """, (
                     datetime.now(),
                     # record_snapshot은 total_value_krw로, 구 호출부는 total_krw로
@@ -495,19 +504,14 @@ class DatabaseManager:
                     portfolio_data.get(
                         "total_value_krw", portfolio_data.get("total_krw", 0)
                     ),
-                    krw_balance,
-                    btc_balance, btc_value,
-                    eth_balance, eth_value,
-                    xrp_balance, xrp_value,
-                    sol_balance, sol_value,
                     json.dumps(serialize_for_json(portfolio_data))
                 ))
-                
+
                 record_id = cursor.lastrowid
                 conn.commit()
-                
+
                 return record_id
-                
+
         except Exception as e:
             logger.error(f"포트폴리오 스냅샷 저장 실패: {e}")
             raise
@@ -854,23 +858,26 @@ class DatabaseManager:
         try:
             with self.get_connection() as conn:
                 cursor = conn.cursor()
+                # 주문 상세는 twap_orders_detail 컬럼에 저장된다 —
+                # 존재하지 않는 execution_plan 컬럼을 SELECT하면 예외가
+                # 삼켜져 항상 빈 리스트가 반환됐다
                 cursor.execute("""
-                    SELECT id, start_time, execution_plan, status, created_at
-                    FROM twap_executions 
+                    SELECT id, start_time, twap_orders_detail, status, created_at
+                    FROM twap_executions
                     WHERE status = 'active'
                     ORDER BY created_at DESC
                 """)
-                
+
                 results = []
                 for row in cursor.fetchall():
                     results.append({
                         "id": row[0],
                         "start_time": row[1],
-                        "execution_plan": json.loads(row[2]),
+                        "execution_plan": json.loads(row[2]) if row[2] else None,
                         "status": row[3],
                         "created_at": row[4]
                     })
-                
+
                 return results
             
         except Exception as e:
@@ -937,19 +944,21 @@ class DatabaseManager:
             with self.get_connection() as conn:
                 cursor = conn.cursor()
                 
-                # 먼저 rebalance_results 테이블에서 조회
+                # save_rebalance_result가 쓰는 테이블은 rebalance_history다 —
+                # 아무도 쓰지 않는 rebalance_results를 읽으면 영원히 비어 있다
                 cursor.execute("""
-                    SELECT timestamp, success, orders_executed, total_value_before, total_value_after
-                    FROM rebalance_results 
+                    SELECT rebalance_date, success, orders_executed,
+                           total_value_before, total_value_after
+                    FROM rebalance_history
                     WHERE success = 1
-                    ORDER BY timestamp DESC 
+                    ORDER BY rebalance_date DESC
                     LIMIT 1
                 """)
-                
+
                 row = cursor.fetchone()
                 if row:
                     return {
-                        "timestamp": row["timestamp"],
+                        "timestamp": row["rebalance_date"],
                         "success": bool(row["success"]),
                         "orders_executed": row["orders_executed"],
                         "total_value_before": row["total_value_before"],

--- a/tests/test_alert_system.py
+++ b/tests/test_alert_system.py
@@ -694,3 +694,67 @@ class TestAlertSystemUncoveredLines:
 
         # 실패 결과
         assert isinstance(results, dict)
+
+
+class TestInfoAlertChannelRouting:
+    """운영 회귀 방지: send_info_alert의 alert_type 기본값 'system_info'가
+    alert_levels 조회 키로 그대로 쓰여 config의 info: 채널 설정이 죽어
+    있었다 — error/warning 외 모든 유형은 info 레벨 설정을 따라야 함"""
+
+    def _make(self, alert_levels):
+        config = Mock()
+        config.get_notification_config.return_value = {
+            'email': {'enabled': False},
+            'slack': {'enabled': True, 'webhook_url': 'https://hooks.test/x'},
+            'alert_levels': alert_levels,
+        }
+        coordinator = Mock()
+        coordinator.should_send_alert.return_value = True
+        with patch('src.monitoring.alert_system.get_system_coordinator',
+                   return_value=coordinator):
+            return AlertSystem(config)
+
+    def test_info_class_alert_uses_info_level_channels(self):
+        alerts = self._make({
+            'error': ['slack'], 'warning': ['slack'], 'info': ['email'],
+        })
+        results = alerts.send_info_alert("데일리 브리핑", "본문")
+        # info: ['email'] 설정을 따라야 함 — 'system_info' 키 미스로
+        # ['slack'] 폴백이 되면 안 됨
+        assert 'email' in results
+        assert 'slack' not in results
+
+    def test_error_alert_still_uses_error_channels(self):
+        alerts = self._make({
+            'error': ['slack'], 'warning': ['slack'], 'info': ['email'],
+        })
+        with patch.object(AlertSystem, '_send_slack', return_value=True):
+            results = alerts.send_error_alert("오류", "본문")
+        assert 'slack' in results
+
+
+class TestMentionListNotMutated:
+    """멘션 리스트 in-place 오염 방지 — 에러 알림마다 @here가 설정 리스트에
+    누적되면 같은 프로세스의 두 번째 알림부터 '@here @here …'가 된다"""
+
+    def test_repeated_error_alerts_do_not_accumulate_here(self):
+        config = Mock()
+        default_users = ['U000000']
+        config.get_notification_config.return_value = {
+            'email': {'enabled': False},
+            'slack': {
+                'enabled': True, 'webhook_url': 'https://hooks.test/x',
+                'mentions': {'default_users': default_users},
+            },
+            'alert_levels': {'error': ['slack'], 'warning': ['slack'],
+                             'info': ['slack']},
+        }
+        coordinator = Mock()
+        coordinator.should_send_alert.return_value = True
+        with patch('src.monitoring.alert_system.get_system_coordinator',
+                   return_value=coordinator):
+            alerts = AlertSystem(config)
+        first = alerts._generate_mention_text("error")
+        second = alerts._generate_mention_text("error")
+        assert first == second
+        assert default_users == ['U000000']  # 설정 원본 불변

--- a/tests/test_backtest_longterm.py
+++ b/tests/test_backtest_longterm.py
@@ -128,3 +128,13 @@ def test_sweep_starts_returns_result_per_start():
         assert isinstance(result, BacktestResult)
         assert start_date == df.index[start]
         assert len(result.weekly_values) == len(df) - start
+
+
+def test_flat_market_sharpe_not_inflated_by_deposits():
+    """입금은 수익이 아니다 — 횡보장에서 주간 적립(250k)이 수익률로 잡히면
+    Sharpe가 크게 양수로 부풀려진다. 비용만 있는 횡보장의 시간가중 Sharpe는
+    0 이하여야 함"""
+    import pandas as pd
+    weekly = pd.DataFrame({"Close": [100.0] * 260})
+    r = run_backtest(weekly)
+    assert r.sharpe <= 0.0

--- a/tests/test_coinone_client.py
+++ b/tests/test_coinone_client.py
@@ -1143,17 +1143,30 @@ class TestGetOrderStatus:
             "avg_price": "50000000"
         }
 
-        result = client.get_order_status("order_123")
+        result = client.get_order_status("order_123", "BTC")
 
         assert result["result"] == "success"
         assert result["status"] == "filled"
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_get_order_status_sends_required_market_params(self, mock_request, client):
+        """v2.1 order/info는 quote/target_currency 필수 — 누락 시 조회가
+        실패해 체결 추적이 전면 불능이 되는 회귀 방지"""
+        mock_request.return_value = {"result": "success"}
+
+        client.get_order_status("order_123", "eth")
+
+        params = mock_request.call_args.args[2]
+        assert params["order_id"] == "order_123"
+        assert params["quote_currency"] == "KRW"
+        assert params["target_currency"] == "ETH"
 
     @patch.object(CoinoneClient, '_make_request')
     def test_get_order_status_404(self, mock_request, client):
         """주문을 찾을 수 없음 (404)"""
         mock_request.side_effect = Exception("404 Not Found")
 
-        result = client.get_order_status("nonexistent_order")
+        result = client.get_order_status("nonexistent_order", "BTC")
 
         assert result["result"] == "success"
         assert result["status"] == "not_found"
@@ -1164,7 +1177,7 @@ class TestGetOrderStatus:
         mock_request.side_effect = Exception("500 Server Error")
 
         with pytest.raises(Exception):
-            client.get_order_status("order_123")
+            client.get_order_status("order_123", "BTC")
 
 
 @pytest.mark.trading
@@ -1181,9 +1194,22 @@ class TestCancelOrder:
         """주문 취소 성공"""
         mock_request.return_value = {"result": "success"}
 
-        result = client.cancel_order("order_123")
+        result = client.cancel_order("order_123", "BTC")
 
         assert result["result"] == "success"
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_cancel_order_sends_required_market_params(self, mock_request, client):
+        """v2.1 order/cancel는 quote/target_currency 필수 — 누락 시 취소가
+        실패해 낡은 지정가가 호가창에 방치되는 회귀 방지"""
+        mock_request.return_value = {"result": "success"}
+
+        client.cancel_order("order_123", "sol")
+
+        params = mock_request.call_args.args[2]
+        assert params["order_id"] == "order_123"
+        assert params["quote_currency"] == "KRW"
+        assert params["target_currency"] == "SOL"
 
     @patch.object(CoinoneClient, '_make_request')
     def test_cancel_order_failure(self, mock_request, client):
@@ -1194,7 +1220,7 @@ class TestCancelOrder:
             "error_msg": "Order cannot be cancelled"
         }
 
-        result = client.cancel_order("order_123")
+        result = client.cancel_order("order_123", "BTC")
 
         assert result["result"] == "error"
 
@@ -1203,7 +1229,7 @@ class TestCancelOrder:
         """주문을 찾을 수 없음 (404) - 이미 완료/취소"""
         mock_request.side_effect = Exception("404 Not Found")
 
-        result = client.cancel_order("completed_order")
+        result = client.cancel_order("completed_order", "BTC")
 
         assert result["result"] == "success"
         assert result["status"] == "not_found"
@@ -1214,7 +1240,7 @@ class TestCancelOrder:
         mock_request.side_effect = Exception("Network error")
 
         with pytest.raises(Exception):
-            client.cancel_order("order_123")
+            client.cancel_order("order_123", "BTC")
 
 
 @pytest.mark.trading
@@ -1597,3 +1623,87 @@ class TestPrivateAPIParamsNone:
         assert result["result"] == "success"
         # params가 None이면 {}로 대체되어 호출됨
         mock_post.assert_called_once()
+
+
+@pytest.mark.trading
+class TestOrderAmbiguityAndTimeout:
+    """운영 회귀 방지: 주문 POST의 네트워크 모호 실패(응답 유실)를 일반
+    실패와 동일 취급해 재시도하면 이중 주문이 발생한다. 또한 requests에
+    timeout이 없으면 크론 전체가 무한 대기한다."""
+
+    @pytest.fixture
+    def client(self):
+        return CoinoneClient(api_key="test", secret_key="test")
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_place_order_network_failure_marked_ambiguous(self, mock_request, client):
+        """접수 여부를 알 수 없는 네트워크 실패 → ambiguous 표시"""
+        import requests as req
+        mock_request.side_effect = req.exceptions.ConnectionError("conn reset")
+
+        result = client.place_order("BTC", "buy", 0.01, price=100_000_000.0)
+
+        assert result["success"] is False
+        assert result.get("ambiguous") is True
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_place_order_client_error_not_ambiguous(self, mock_request, client):
+        """4xx는 서버가 주문을 거부한 것 — 미접수 확정이므로 재시도 안전"""
+        import requests as req
+        response = Mock()
+        response.status_code = 400
+        mock_request.side_effect = req.exceptions.HTTPError(response=response)
+
+        result = client.place_order("BTC", "buy", 0.01, price=100_000_000.0)
+
+        assert result["success"] is False
+        assert not result.get("ambiguous")
+
+    @patch('src.trading.coinone_client.requests.post')
+    def test_private_request_has_timeout(self, mock_post, client):
+        mock_post.return_value.json.return_value = {"result": "success"}
+        mock_post.return_value.raise_for_status = Mock()
+
+        client._make_request("POST", "/v2.1/account/balance/all", {}, is_public=False)
+
+        assert mock_post.call_args.kwargs.get("timeout", 0) > 0
+
+    @patch('src.trading.coinone_client.requests.get')
+    def test_public_request_has_timeout(self, mock_get, client):
+        mock_get.return_value.json.return_value = {"result": "success"}
+        mock_get.return_value.raise_for_status = Mock()
+
+        client._make_request("GET", "/public/v2/ticker_new/KRW/BTC", {}, is_public=True)
+
+        assert mock_get.call_args.kwargs.get("timeout", 0) > 0
+
+
+@pytest.mark.trading
+class TestOrderParamSerialization:
+    """지정가/수량 직렬화 — int() 절삭은 1,000 KRW 미만 자산(소수 호가 단위)
+    에서 슬리피지 캡을 위반하고, str(float)는 1e-4 미만 수량을 지수 표기로
+    보내 주문이 거부될 수 있다"""
+
+    @pytest.fixture
+    def client(self):
+        return CoinoneClient(api_key="test", secret_key="test")
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_limit_price_preserves_fractional_tick(self, mock_request, client):
+        mock_request.return_value = {"result": "success", "order_id": "x"}
+
+        client.place_order("XRP", "sell", 100.0, price=796.5)
+
+        params = mock_request.call_args.args[2]
+        assert params["price"] == "796.5"
+
+    @patch.object(CoinoneClient, '_make_request')
+    def test_limit_qty_fixed_point_not_scientific(self, mock_request, client):
+        mock_request.return_value = {"result": "success", "order_id": "x"}
+
+        client.place_order("BTC", "buy", 6.25e-05, price=160_000_000.0)
+
+        params = mock_request.call_args.args[2]
+        assert "e" not in params["qty"].lower()
+        assert params["qty"] == "0.0000625"
+        assert params["price"] == "160000000"

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -566,40 +566,20 @@ class TestDatabaseManagerQuery:
 
 @pytest.mark.database
 class TestSavePortfolioSnapshot:
-    """포트폴리오 스냅샷 저장 테스트"""
+    """포트폴리오 스냅샷 저장 테스트
+
+    반드시 프로덕션 DDL(_initialize_database) 그대로 테스트한다 —
+    과거에 픽스처가 테이블을 drop하고 다른 스키마로 재생성해서,
+    INSERT가 실제 스키마에 없는 컬럼에 쓰는 치명 버그(운영에서 스냅샷
+    저장이 전부 실패)를 테스트가 가려버린 적이 있다."""
 
     @pytest.fixture
     def db_manager(self, tmp_path):
-        """DatabaseManager 인스턴스"""
+        """DatabaseManager 인스턴스 — 프로덕션 DDL 그대로"""
         db_path = str(tmp_path / "test.db")
         config = Mock()
         config.get = Mock(return_value=db_path)
-        db = DatabaseManager(config)
-        # portfolio_snapshots 테이블 구조 수정
-        with db.get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("DROP TABLE IF EXISTS portfolio_snapshots")
-            cursor.execute("""
-                CREATE TABLE portfolio_snapshots (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    snapshot_date TEXT NOT NULL,
-                    total_value_krw REAL NOT NULL,
-                    krw_balance REAL,
-                    btc_balance REAL,
-                    btc_value_krw REAL,
-                    eth_balance REAL,
-                    eth_value_krw REAL,
-                    xrp_balance REAL,
-                    xrp_value_krw REAL,
-                    sol_balance REAL,
-                    sol_value_krw REAL,
-                    portfolio_data TEXT,
-                    portfolio_detail TEXT,
-                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
-            conn.commit()
-        return db
+        return DatabaseManager(config)
 
     def test_save_portfolio_snapshot_with_assets(self, db_manager):
         """자산 정보가 있는 스냅샷 저장"""
@@ -661,6 +641,46 @@ class TestSavePortfolioSnapshot:
         db_manager.save_portfolio_snapshot({"total_krw": 5_000_000, "assets": {}})
         history = db_manager.get_portfolio_history(days=1)
         assert float(history[0]["total_value_krw"]) == pytest.approx(5_000_000.0)
+
+    def test_save_portfolio_snapshot_stores_full_detail_json(self, db_manager):
+        """자산 상세는 portfolio_detail JSON에 보존 — 자산별 컬럼 없이도
+        (예: 자산 목록 변경) 전체 내역을 복원할 수 있어야 함"""
+        db_manager.save_portfolio_snapshot({
+            "total_value_krw": 100.0,
+            "assets": {"KRW": 40.0, "BTC": {"balance": 0.001, "value_krw": 60.0}},
+        })
+        history = db_manager.get_portfolio_history(days=1)
+        detail = json.loads(history[0]["portfolio_detail"])
+        assert detail["assets"]["BTC"]["value_krw"] == pytest.approx(60.0)
+
+    def test_save_portfolio_snapshot_migrates_legacy_wide_table(self, tmp_path):
+        """구버전 배포본이 만든 wide 스키마(portfolio_detail 없음) DB에서도
+        마이그레이션 후 저장·조회가 동작해야 함"""
+        import sqlite3
+        db_path = str(tmp_path / "legacy.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute("""
+            CREATE TABLE portfolio_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                snapshot_date TEXT NOT NULL,
+                total_value_krw REAL NOT NULL,
+                krw_balance REAL,
+                btc_balance REAL, btc_value_krw REAL,
+                eth_balance REAL, eth_value_krw REAL,
+                xrp_balance REAL, xrp_value_krw REAL,
+                sol_balance REAL, sol_value_krw REAL,
+                portfolio_data TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.commit()
+        conn.close()
+        config = Mock()
+        config.get = Mock(return_value=db_path)
+        db = DatabaseManager(config)
+        db.save_portfolio_snapshot({"total_value_krw": 77.0, "assets": {}})
+        history = db.get_portfolio_history(days=1)
+        assert float(history[0]["total_value_krw"]) == pytest.approx(77.0)
 
 
 @pytest.mark.database
@@ -1880,3 +1900,67 @@ class TestTradedKrwToday:
 
     def test_zero_when_no_trades(self, db_manager):
         assert db_manager.get_traded_krw_today() == 0.0
+
+
+@pytest.mark.database
+class TestLatentQueryColumnMismatches:
+    """작성 테이블과 조회 테이블/컬럼 불일치 — 항상 빈 결과가 나오던 잠재 경로"""
+
+    @pytest.fixture
+    def db_manager(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        config = Mock()
+        config.get = Mock(return_value=db_path)
+        return DatabaseManager(config)
+
+    def test_latest_rebalance_record_reads_saved_history(self, db_manager):
+        """save_rebalance_result는 rebalance_history에 쓰는데 조회는
+        rebalance_results를 봐서 영원히 비어 있었다"""
+        db_manager.save_rebalance_result({
+            "success": True,
+            "total_value_before": 100.0,
+            "total_value_after": 101.0,
+            "executed_orders": [1, 2],
+            "failed_orders": [],
+            "rebalance_summary": {"market_season": "neutral"},
+        })
+        record = db_manager.get_latest_rebalance_record()
+        assert record is not None
+        assert record["success"] is True
+        assert record["orders_executed"] == 2
+
+    def test_update_twap_status_with_result_data_persists(self, db_manager):
+        """result_data 컬럼 부재로 상태 업데이트가 조용히 실패하던 경로"""
+        with db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT INTO twap_executions (execution_id, status, start_time)"
+                " VALUES ('e1', 'executing', '2026-01-01T00:00:00')"
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+        db_manager.update_twap_execution_status(
+            row_id, "completed", result_data={"filled": 1}
+        )
+        with db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT status FROM twap_executions WHERE id = ?", (row_id,)
+            )
+            assert cursor.fetchone()[0] == "completed"
+
+    def test_get_active_twap_executions_reads_existing_column(self, db_manager):
+        """존재하지 않는 execution_plan 컬럼 SELECT → 예외 삼킴 → 항상 []"""
+        import json as _json
+        with db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT INTO twap_executions "
+                "(execution_id, status, start_time, twap_orders_detail)"
+                " VALUES ('e2', 'active', '2026-01-01T00:00:00', ?)",
+                (_json.dumps([{"asset": "BTC"}]),),
+            )
+            conn.commit()
+        results = db_manager.get_active_twap_executions()
+        assert len(results) == 1
+        assert results[0]["execution_plan"] == [{"asset": "BTC"}]

--- a/tests/test_kairos_main.py
+++ b/tests/test_kairos_main.py
@@ -275,7 +275,7 @@ def test_daily_check_records_snapshot_even_without_trades():
 
 def test_monthly_report_uses_portfolio_return_when_history_exists():
     sys_, _, alerts = make_system()
-    sys_.portfolio.get_value_change_30d.return_value = 0.08
+    sys_.portfolio.get_value_change_30d.return_value = (0.08, 30)
     sys_.binance = MagicMock()
     import pandas as pd
     sys_.binance.get_historical_klines.return_value = pd.DataFrame(
@@ -486,6 +486,50 @@ def test_monthly_report_exception_sends_error_alert():
     alerts.send_error_alert.assert_called_once()
 
 
+def test_sell_proceeds_fund_subsequent_buys():
+    """매도 우선 실행의 목적은 매수 자금 확보 — 가드가 매도 대금을 못 보면
+    매도만 체결되고 매수가 거부되는 한쪽 다리 리밸런싱이 된다"""
+    from src.risk.guard import RiskGuard, RiskLimits
+    # 내부 이탈: BTC 22M(가중치 50% 대비 -27%) → BTC 8M 매수 + 나머지 매도
+    holdings = {"BTC": 22_000_000, "ETH": 22_000_000,
+                "XRP": 8_000_000, "SOL": 8_000_000}
+    sys_, executor, _ = make_system(holdings=holdings, krw=40_000_000)
+    executor.execute.side_effect = lambda req: MagicMock(
+        success=True, filled_krw=req.amount_krw
+    )
+    # KRW 하한 38%: 매도 대금(+8M) 없이는 BTC 8M 매수가 거부되는 수준
+    sys_.guard = RiskGuard(RiskLimits(
+        max_single_trade_krw=10_000_000, max_daily_volume_krw=50_000_000,
+        min_krw_ratio=0.38, fomo_surge_threshold=0.15,
+    ))
+    result = sys_.run_daily_check(dry_run=False)
+    sides = {c.args[0].asset: c.args[0].side
+             for c in executor.execute.call_args_list}
+    assert sides.get("BTC") == "buy"
+    assert not result["rejected"]
+
+
+def test_min_krw_floor_enforced_across_batch():
+    """여러 매수가 각자 배치 시작 시점 잔고로 검증되면 합산 후 KRW 하한이
+    뚫린다 — 체결마다 잔고를 갱신해 하한을 실제로 집행해야 함"""
+    from src.risk.guard import RiskGuard, RiskLimits
+    holdings = {"BTC": 20_000_000, "ETH": 12_000_000,
+                "XRP": 4_000_000, "SOL": 4_000_000}
+    sys_, executor, _ = make_system(holdings=holdings, krw=60_000_000)
+    executor.execute.side_effect = lambda req: MagicMock(
+        success=True, filled_krw=req.amount_krw
+    )
+    # 하한 45% → 매수 여력은 60M-45M=15M뿐인데 밴드 복귀 계획은 20M 매수
+    sys_.guard = RiskGuard(RiskLimits(
+        max_single_trade_krw=10_000_000, max_daily_volume_krw=50_000_000,
+        min_krw_ratio=0.45, fomo_surge_threshold=0.15,
+    ))
+    result = sys_.run_daily_check(dry_run=False)
+    bought = sum(c.args[0].amount_krw for c in executor.execute.call_args_list)
+    assert bought <= 15_000_000 + 1
+    assert result["rejected"]  # 하한에 걸린 잔여 매수는 거부로 기록
+
+
 # ------------------------------------------------------------- 데일리 브리핑
 def test_daily_briefing_always_sends_even_without_trades():
     """브리핑은 무거래 날에도 무조건 발송 — 매일 오는 생존 신호"""
@@ -540,3 +584,52 @@ def test_daily_briefing_includes_daily_change_when_history_exists():
     sys_.run_daily_briefing()
     _, body = alerts.send_info_alert.call_args.args
     assert "+2.0%" in body
+
+
+# --------------------------------------------------- 조립 단계 크래시 알림
+def test_main_assembly_failure_sends_alert_and_exits_nonzero(monkeypatch):
+    """fail-loud 계약: config·DB·클라이언트 조립 실패는 _guarded 밖이라
+    Slack 없이 조용히 죽었다 — main이 잡아서 통지하고 종료코드 1"""
+    import sys as _sys
+    import kairos1_main as km
+    monkeypatch.setattr(_sys, "argv", ["kairos1_main.py", "briefing"])
+    monkeypatch.setattr(
+        km.KairosSimple, "from_yaml",
+        MagicMock(side_effect=RuntimeError("db locked")),
+    )
+    sent = {}
+    monkeypatch.setattr(
+        km, "_crash_alert_best_effort",
+        lambda command, config_path, error: sent.update(
+            command=command, error=str(error)
+        ),
+    )
+    rc = km.main()
+    assert rc == 1
+    assert sent["command"] == "briefing"
+    assert "db locked" in sent["error"]
+
+
+def test_crash_alert_falls_back_to_webhook(monkeypatch):
+    """AlertSystem 조립조차 실패(예: config 파손)하면 SLACK_WEBHOOK_URL로
+    직접 POST — 어떤 실패 클래스에서도 Slack이 조용하면 안 됨"""
+    from unittest.mock import patch as _patch
+    import kairos1_main as km
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.example/x")
+    with _patch("src.monitoring.alert_system.AlertSystem",
+                side_effect=Exception("config broken")):
+        with _patch("requests.post") as mock_post:
+            km._crash_alert_best_effort(
+                "daily-check", "config/config.yaml", RuntimeError("yaml error")
+            )
+    assert mock_post.called
+    assert mock_post.call_args.args[0] == "https://hooks.slack.example/x"
+    assert "yaml error" in str(mock_post.call_args.kwargs.get("json"))
+
+
+def test_dry_run_does_not_record_snapshot():
+    """--dry-run 스모크 테스트가 스냅샷을 남기면 전일 대비·30일 수익률
+    기준선이 오염된다 — dry-run은 DB에 아무것도 쓰지 않는다"""
+    sys_, _, _ = make_system()
+    sys_.run_daily_check(dry_run=True)
+    sys_.portfolio.record_snapshot.assert_not_called()

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -82,18 +82,30 @@ def test_get_prices_krw_invalid_price_raises():
         svc.get_prices_krw(["BTC"])
 
 
-def test_price_change_24h_computed_from_daily_klines():
+def test_price_change_24h_uses_rolling_hourly_window():
+    """운영 회귀 방지: 일봉 iloc[-2] 기준은 'UTC 자정 이후 변동'이라
+    09:10 KST(=00:10 UTC) 크론 실행 시 항상 ≈0%가 되어 크래시 가드·FOMO
+    가드가 결코 발동하지 않았다 — 반드시 시간봉 24시간 창으로 계산"""
     svc, binance, _, _ = make_service()
+    # 26개 시간봉: 24시간 전(-25번째) 100 → 현재(-1번째) 116
+    closes = [90.0, 100.0] + [110.0] * 23 + [116.0]
     binance.get_historical_klines.return_value = pd.DataFrame(
-        {"Close": [100.0, 116.0]}
+        {"Close": pd.Series(closes)}
     )
     change = svc.get_price_change_24h(["BTC"])
     assert change["BTC"] == pytest.approx(0.16)
+    kwargs = binance.get_historical_klines.call_args.kwargs
+    assert kwargs["interval"] == "1h"
+    # 제공자는 기본 5년치를 긁는다 — 시작 시각을 좁혀야 함
+    assert kwargs.get("start_date") is not None
 
 
 def test_price_change_24h_missing_data_raises():
+    """시간봉이 24시간치 미만이면 fail-loud (가드가 0%로 착각하면 안 됨)"""
     svc, binance, _, _ = make_service()
-    binance.get_historical_klines.return_value = pd.DataFrame({"Close": [100.0]})
+    binance.get_historical_klines.return_value = pd.DataFrame(
+        {"Close": pd.Series([100.0] * 10)}
+    )
     with pytest.raises(DataUnavailableError):
         svc.get_price_change_24h(["BTC"])
 

--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -200,6 +200,16 @@ class TestFillConfirmation:
         assert not report.success
         assert report.filled_krw == pytest.approx(500_000, rel=0.01)
 
+    def test_fill_polling_and_cancel_pass_asset(self):
+        """order/info·order/cancel은 마켓(quote/target_currency) 지정이 필수 —
+        자산 미전달 시 잘못된 마켓을 조회해 체결 추적·취소가 불능이 된다"""
+        live = {"order": {"status": "live", "remain_qty": "1"}}
+        ex, coinone = self.make([live, live])
+        ex.execute(OrderRequest("ETH", "buy", 1_000_000, "dca"))
+        for call in coinone.get_order_status.call_args_list:
+            assert call.args[1] == "ETH"
+        assert coinone.cancel_order.call_args.args[1] == "ETH"
+
     def test_not_found_before_cancel_treated_as_filled(self):
         # 체결 완료된 주문은 조회에서 사라질 수 있음 (클라이언트가 not_found 반환)
         ex, coinone = self.make([{"result": "success", "status": "not_found"}])
@@ -207,3 +217,26 @@ class TestFillConfirmation:
         assert report.success
         assert report.filled_krw == pytest.approx(1_000_000)
         coinone.cancel_order.assert_not_called()
+
+
+def test_ambiguous_network_failure_not_retried():
+    """주문 도달 여부를 모르는 네트워크 실패는 재시도 금지 — 응답만 유실된
+    경우 재제출하면 이중 주문(2배 매수)이 된다. fail-safe로 즉시 중단."""
+    ex, coinone = make_executor(max_retries=3)
+    coinone.place_order.return_value = {
+        "success": False, "ambiguous": True, "error": "conn reset"
+    }
+    report = ex.execute(OrderRequest("BTC", "buy", 1_000_000, "dca"))
+    assert not report.success
+    assert coinone.place_order.call_count == 1
+    assert "불확실" in report.error
+
+
+def test_custom_slippage_cap_respected():
+    """config execution.slippage_cap이 실제 지정가에 반영돼야 함 —
+    하드코딩 상수만 쓰면 설정이 죽은 문서가 된다"""
+    ex, coinone = make_executor(price=100_000_000.0, slippage_cap=0.002)
+    ex.execute(OrderRequest("BTC", "buy", 1_000_000, "dca"))
+    assert coinone.place_order.call_args.kwargs["price"] == pytest.approx(
+        100_000_000.0 * 1.002
+    )

--- a/tests/test_performance_tracker.py
+++ b/tests/test_performance_tracker.py
@@ -348,11 +348,12 @@ class TestCalculateTradeStatistics:
         assert stats["avg_trade_size"] == 0.0
 
     def test_all_successful_trades(self, tracker):
-        """모든 거래 성공"""
+        """trade_history 실제 컬럼(fee_krw/amount_krw) 기반 집계 —
+        기록되는 거래는 체결분뿐이므로 전 행이 성공 거래"""
         trades = [
-            {"status": "filled", "fee": 100, "amount": 10000},
-            {"status": "filled", "fee": 150, "amount": 15000},
-            {"status": "filled", "fee": 200, "amount": 20000}
+            {"side": "buy", "fee_krw": 100, "amount_krw": 10000},
+            {"side": "buy", "fee_krw": 150, "amount_krw": 15000},
+            {"side": "sell", "fee_krw": 200, "amount_krw": 20000}
         ]
 
         stats = tracker._calculate_trade_statistics(trades)
@@ -362,20 +363,6 @@ class TestCalculateTradeStatistics:
         assert stats["success_rate"] == 1.0
         assert stats["total_fees"] == 450
         assert stats["avg_trade_size"] == pytest.approx(15000, rel=0.01)
-
-    def test_mixed_trade_status(self, tracker):
-        """혼합 거래 상태"""
-        trades = [
-            {"status": "filled", "fee": 100, "amount": 10000},
-            {"status": "cancelled", "fee": 0, "amount": 5000},
-            {"status": "filled", "fee": 200, "amount": 20000}
-        ]
-
-        stats = tracker._calculate_trade_statistics(trades)
-
-        assert stats["total_trades"] == 3
-        assert stats["successful_trades"] == 2
-        assert stats["success_rate"] == pytest.approx(0.667, rel=0.01)
 
 
 @pytest.mark.monitoring
@@ -404,10 +391,11 @@ class TestGetCurrentAllocation:
         assert allocation is None
 
     def test_krw_only(self, tracker):
-        """KRW만 보유"""
+        """KRW만 보유 — 자산 상세는 portfolio_detail JSON에서 복원"""
+        import json as _json
         snapshot = {
             "total_value_krw": 1000000,
-            "krw_balance": 1000000
+            "portfolio_detail": _json.dumps({"assets": {"KRW": 1000000}}),
         }
         allocation = tracker._get_current_allocation(snapshot)
 
@@ -852,3 +840,48 @@ class TestBenchmarkReturnRealData:
             tracker._calculate_benchmark_return(
                 datetime(2026, 6, 1), datetime(2026, 7, 1)
             )
+
+
+@pytest.mark.monitoring
+class TestTradeStatisticsColumns:
+    """trade_history 실제 컬럼(side/fee_krw/amount_krw) 사용 — 존재하지 않는
+    status/fee/amount 키를 읽어 수수료·평균 거래액이 항상 0이던 버그"""
+
+    @pytest.fixture
+    def tracker(self):
+        config = Mock()
+        config.get_risk_config.return_value = {"three_line_check": {}}
+        return PerformanceTracker(config, Mock())
+
+    def test_statistics_from_actual_columns(self, tracker):
+        rows = [
+            {"side": "buy", "amount_krw": 100_000.0, "fee_krw": 200.0},
+            {"side": "sell", "amount_krw": 300_000.0, "fee_krw": None},
+        ]
+        stats = tracker._calculate_trade_statistics(rows)
+        assert stats["total_trades"] == 2
+        assert stats["total_fees"] == pytest.approx(200.0)
+        assert stats["avg_trade_size"] == pytest.approx(200_000.0)
+
+    def test_returns_skip_corrupt_zero_values(self, tracker):
+        """과거 버그로 0이 저장된 스냅샷이 섞여도 inf가 나오면 안 됨"""
+        import numpy as np
+        returns = tracker._calculate_returns([100.0, 0.0, 110.0])
+        assert np.isfinite(returns).all()
+
+    def test_allocation_parsed_from_portfolio_detail_json(self, tracker):
+        """스냅샷 자산 배분은 portfolio_detail JSON에서 복원 — 자산별
+        컬럼은 현 스키마에 존재하지 않는다"""
+        import json as _json
+        snapshot = {
+            "total_value_krw": 100_000.0,
+            "portfolio_detail": _json.dumps({
+                "assets": {
+                    "KRW": 40_000.0,
+                    "BTC": {"balance": 0.001, "value_krw": 60_000.0},
+                }
+            }),
+        }
+        allocation = tracker._get_current_allocation(snapshot)
+        assert allocation["KRW"] == pytest.approx(0.4)
+        assert allocation["BTC"] == pytest.approx(0.6)

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -81,14 +81,32 @@ def test_record_snapshot_saves_totals_and_assets():
     assert data["assets"]["KRW"] == pytest.approx(40_000_000.0)
 
 
-def test_value_change_30d_from_earliest_snapshot():
+def test_value_change_30d_returns_change_and_window_days():
+    """수익률은 실제 관측 창(일수)과 함께 반환 — 5일치 데이터로 계산한
+    수익률을 30일 BTC 벤치마크와 비교하는 사과-오렌지 비교 방지"""
+    from datetime import datetime, timedelta
     svc, db = make_service(balances={}, prices={})
+    d28 = (datetime.now() - timedelta(days=28)).strftime("%Y-%m-%d 09:10:00")
+    d1 = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d 09:10:00")
     db.get_portfolio_history.return_value = [
-        {"snapshot_date": "2026-06-14 09:10:00", "total_value_krw": 80_000_000.0},
-        {"snapshot_date": "2026-07-13 09:10:00", "total_value_krw": 95_000_000.0},
+        {"snapshot_date": d28, "total_value_krw": 80_000_000.0},
+        {"snapshot_date": d1, "total_value_krw": 95_000_000.0},
     ]
-    change = svc.get_value_change_30d(current_total_krw=100_000_000.0)
+    change, days = svc.get_value_change_30d(current_total_krw=100_000_000.0)
     assert change == pytest.approx(0.25)  # 80M → 100M
+    assert days == 28
+
+
+def test_value_change_30d_excludes_same_day_baseline():
+    """당일 09:10 스냅샷을 기준선으로 잡으면 수익률이 항상 ≈0%로 나온다 —
+    오늘 이전 스냅샷이 없으면 None (데이터 축적 중)"""
+    from datetime import datetime
+    svc, db = make_service(balances={}, prices={})
+    today = datetime.now().strftime("%Y-%m-%d 09:10:00")
+    db.get_portfolio_history.return_value = [
+        {"snapshot_date": today, "total_value_krw": 100_000_000.0},
+    ]
+    assert svc.get_value_change_30d(current_total_krw=100_500_000.0) is None
 
 
 def test_value_change_30d_none_when_no_history():

--- a/tests/test_rate_limited_client.py
+++ b/tests/test_rate_limited_client.py
@@ -217,225 +217,72 @@ class TestRateLimitedClientErrorHandling:
             assert "API Error" in str(excinfo.value)
 
 
-class TestWrapApiMethod:
-    """_wrap_api_method 메서드 테스트"""
+class TestRateLimitingActuallyApplied:
+    """운영 회귀 방지: 명시적 패스스루 메서드가 __getattr__ 래핑을 가려
+    거래 경로 전체가 무제한이던 버그 — 모든 API 메서드는 리미터를 거쳐야 함"""
 
     @pytest.fixture
-    def mock_original_client(self):
-        """원본 클라이언트 Mock"""
-        client = Mock()
-        client.get_balances.return_value = {'KRW': 1000000}
-        return client
+    def mock_coord(self):
+        coordinator = Mock()
+        coordinator.api_rate_limiter = AsyncMock()
+        coordinator.api_rate_limiter.acquire = AsyncMock()
+        return coordinator
 
-    def test_wrap_api_method_sync_mode(self, mock_original_client):
-        """동기 모드에서 API 메서드 래핑"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
+    def make_client(self, original, coord):
+        with patch('src.trading.rate_limited_client.get_system_coordinator',
+                   return_value=coord):
+            return RateLimitedCoinoneClient(original)
 
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
+    def test_trading_path_methods_go_through_limiter(self, mock_coord):
+        """place_order·get_order_status 등 파이프라인이 쓰는 모든 호출이
+        rate limiter acquire를 거쳐야 함"""
+        original = Mock()
+        original.place_order.return_value = {'success': True}
+        original.get_order_status.return_value = {}
+        original.cancel_order.return_value = {}
+        original.get_latest_price.return_value = 1.0
+        original.get_balances.return_value = {}
+        client = self.make_client(original, mock_coord)
 
-            # 이미 실행 중인 이벤트 루프 시뮬레이션
-            with patch('asyncio.get_running_loop') as mock_get_loop:
-                mock_loop = Mock()
-                mock_loop.is_running.return_value = True
-                mock_get_loop.return_value = mock_loop
+        client.place_order(currency='BTC', side='buy', amount=0.01)
+        client.get_order_status('123', 'BTC')
+        client.cancel_order('123', 'BTC')
+        client.get_latest_price('BTC')
+        client.get_balances()
 
-                # __getattr__을 통해 래핑된 메서드 호출
-                result = client.get_balances()
+        assert mock_coord.api_rate_limiter.acquire.call_count == 5
 
-                # 결과 확인
-                assert result == {'KRW': 1000000}
+    def test_method_called_exactly_once_when_limiter_fails(self, mock_coord):
+        """리미터 획득 실패는 호출을 막지 않되, 메서드는 정확히 1회만 —
+        폴백 재호출로 주문이 이중 제출되던 결함 회귀 방지"""
+        mock_coord.api_rate_limiter.acquire = AsyncMock(
+            side_effect=Exception("limiter down")
+        )
+        original = Mock()
+        original.place_order.return_value = {'success': True}
+        client = self.make_client(original, mock_coord)
 
-    def test_wrap_api_method_exception_handling(self, mock_original_client):
-        """래핑된 메서드 예외 처리 후 폴백"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = Mock()
-        # 에러 발생하도록 설정
-        mock_coord.api_rate_limiter.acquire = Mock(side_effect=Exception("Test error"))
+        result = client.place_order(currency='BTC', side='buy', amount=0.01)
 
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
+        assert result == {'success': True}
+        assert original.place_order.call_count == 1
 
-            # __getattr__을 통해 래핑된 메서드 호출 - 에러 시 원본 메서드로 폴백
-            result = client.get_balances()
+    def test_method_exception_propagates_without_second_call(self, mock_coord):
+        """원본 메서드 실패 시 예외 전파 — 부작용 있는 호출의 이중 실행 금지"""
+        original = Mock()
+        original.place_order.side_effect = Exception("API Error")
+        client = self.make_client(original, mock_coord)
 
-            # 원본 메서드가 호출되어 결과 반환
-            assert result == {'KRW': 1000000}
+        with pytest.raises(Exception, match="API Error"):
+            client.place_order(currency='BTC', side='buy', amount=0.01)
 
+        assert original.place_order.call_count == 1
 
-class TestAsyncApiCall:
-    """_async_api_call 메서드 테스트"""
+    def test_non_api_attributes_not_wrapped(self, mock_coord):
+        """네트워크 호출이 아닌 헬퍼(get_price_unit 등)는 리미터 미적용"""
+        original = Mock()
+        original.get_price_unit.return_value = 1000.0
+        client = self.make_client(original, mock_coord)
 
-    @pytest.fixture
-    def mock_original_client(self):
-        """원본 클라이언트 Mock"""
-        client = Mock()
-        client.get_balances.return_value = {'KRW': 2000000}
-        return client
-
-    @pytest.mark.asyncio
-    async def test_async_api_call(self, mock_original_client):
-        """비동기 API 호출"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-        mock_coord.api_rate_limiter.acquire = AsyncMock()
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            result = await client._async_api_call(
-                mock_original_client.get_balances,
-                "get_balances"
-            )
-
-            # 속도 제한 acquire 호출 확인
-            mock_coord.api_rate_limiter.acquire.assert_called_once()
-            assert result == {'KRW': 2000000}
-
-    @pytest.mark.asyncio
-    async def test_async_api_call_with_args(self, mock_original_client):
-        """인자 포함 비동기 API 호출"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-
-        mock_original_client.get_latest_price.return_value = 50000000.0
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            result = await client._async_api_call(
-                mock_original_client.get_latest_price,
-                "get_latest_price",
-                "BTC"
-            )
-
-            mock_original_client.get_latest_price.assert_called_once_with("BTC")
-            assert result == 50000000.0
-
-    @pytest.mark.asyncio
-    async def test_async_api_call_with_kwargs(self, mock_original_client):
-        """키워드 인자 포함 비동기 API 호출"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-
-        mock_original_client.place_order.return_value = {'order_id': '456'}
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            result = await client._async_api_call(
-                mock_original_client.place_order,
-                "place_order",
-                currency="BTC",
-                side="buy"
-            )
-
-            mock_original_client.place_order.assert_called_once_with(currency="BTC", side="buy")
-            assert result['order_id'] == '456'
-
-
-class TestWrapApiMethodAdvanced:
-    """_wrap_api_method 추가 테스트 (누락 라인 커버)"""
-
-    @pytest.fixture
-    def mock_original_client(self):
-        """원본 클라이언트 Mock"""
-        client = Mock()
-        client.get_balances.return_value = {'KRW': 3000000}
-        client.get_ticker.return_value = {'price': 50000000}
-        return client
-
-    def test_wrap_api_method_new_event_loop(self, mock_original_client):
-        """이벤트 루프가 없을 때 새 루프 생성"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-        mock_coord.api_rate_limiter.acquire = AsyncMock()
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            # 이벤트 루프가 없는 상황 시뮬레이션
-            with patch('asyncio.get_running_loop', side_effect=RuntimeError("No running event loop")):
-                # 새 루프 생성 mock
-                mock_loop = MagicMock()
-                mock_loop.is_running.return_value = False
-                mock_loop.run_until_complete = MagicMock(return_value={'KRW': 3000000})
-
-                with patch('asyncio.new_event_loop', return_value=mock_loop) as mock_new_loop:
-                    with patch('asyncio.set_event_loop') as mock_set_loop:
-                        # __getattr__를 통해 API 메서드 호출
-                        wrapped = client._wrap_api_method(mock_original_client.get_ticker, "get_ticker")
-                        result = wrapped()
-
-                        # 새 루프 생성 확인
-                        mock_new_loop.assert_called_once()
-                        mock_set_loop.assert_called_once_with(mock_loop)
-                        assert result == {'KRW': 3000000}
-
-    def test_wrap_api_method_running_loop_direct_call(self, mock_original_client):
-        """실행 중인 루프에서 직접 호출 (동기 모드)"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            # 실행 중인 루프 시뮬레이션
-            mock_loop = MagicMock()
-            mock_loop.is_running.return_value = True
-
-            with patch('asyncio.get_running_loop', return_value=mock_loop):
-                wrapped = client._wrap_api_method(mock_original_client.get_balances, "get_balances")
-                result = wrapped()
-
-                # 원본 메서드 직접 호출 확인
-                mock_original_client.get_balances.assert_called()
-                assert result == {'KRW': 3000000}
-
-    def test_wrap_api_method_exception_fallback(self, mock_original_client):
-        """예외 발생 시 원본 메서드로 폴백"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            # 예외 발생 시뮬레이션
-            with patch('asyncio.get_running_loop', side_effect=RuntimeError("No running loop")):
-                with patch('asyncio.new_event_loop', side_effect=Exception("Loop creation failed")):
-                    wrapped = client._wrap_api_method(mock_original_client.get_balances, "get_balances")
-                    result = wrapped()
-
-                    # 예외 발생해도 원본 메서드 호출
-                    assert result == {'KRW': 3000000}
-
-    def test_wrap_api_method_run_until_complete(self, mock_original_client):
-        """run_until_complete로 비동기 API 호출"""
-        mock_coord = Mock()
-        mock_coord.api_rate_limiter = AsyncMock()
-        mock_coord.api_rate_limiter.acquire = AsyncMock()
-
-        with patch('src.trading.rate_limited_client.get_system_coordinator', return_value=mock_coord):
-            client = RateLimitedCoinoneClient(mock_original_client)
-
-            # 이벤트 루프가 없고 새 루프 생성
-            with patch('asyncio.get_running_loop', side_effect=RuntimeError("No loop")):
-                # 실제로 새 루프를 생성하고 run_until_complete 호출
-                mock_loop = MagicMock()
-                mock_loop.is_running.return_value = False
-
-                # run_until_complete가 비동기 함수를 실행하고 결과 반환
-                async def mock_async_call(*args, **kwargs):
-                    return {'KRW': 3000000}
-
-                mock_loop.run_until_complete.side_effect = lambda coro: asyncio.get_event_loop().run_until_complete(
-                    mock_async_call()
-                ) if asyncio.iscoroutine(coro) else {'KRW': 3000000}
-
-                with patch('asyncio.new_event_loop', return_value=mock_loop):
-                    with patch('asyncio.set_event_loop'):
-                        wrapped = client._wrap_api_method(mock_original_client.get_balances, "get_balances")
-                        result = wrapped()
-
-                        assert mock_loop.run_until_complete.called or result == {'KRW': 3000000}
+        assert client.get_price_unit('BTC', 100.0) == 1000.0
+        mock_coord.api_rate_limiter.acquire.assert_not_called()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -42,3 +42,18 @@ def test_monthly_report_includes_vs_benchmark_and_sends_alert():
     assert report["btc_benchmark_return"] == pytest.approx(0.10)
     assert report["excess_return"] == pytest.approx(0.05)
     assert alerts.send_info_alert.called
+
+
+def test_monthly_report_benchmark_matches_observation_window():
+    """포트폴리오 수익률이 5일치 관측이면 벤치마크도 5일로 — 서로 다른
+    창의 수익률을 빼서 초과수익이라 주장하면 안 됨"""
+    reporter, alerts = make_reporter(btc_closes=[100.0, 105.0, 110.0])
+    report = reporter.monthly_report(
+        portfolio_return=0.02, total_value_krw=100_000_000, crypto_ratio=0.60,
+        window_days=5,
+    )
+    reporter.binance.get_historical_klines.assert_called_once()
+    assert reporter.binance.get_historical_klines.call_args.kwargs["limit"] == 6
+    assert report["window_days"] == 5
+    _, body = alerts.send_info_alert.call_args.args
+    assert "5일" in body

--- a/tests/test_strategy_rebalance.py
+++ b/tests/test_strategy_rebalance.py
@@ -117,3 +117,33 @@ class TestCrashGuard:
             threshold=-0.10, buy_fraction=0.5, min_trade_krw=10_000,
         )
         assert out == []  # 7,500 < 최소 주문 → 제외
+
+
+def test_fully_demoted_asset_triggers_own_sell():
+    """가중치 0으로 완전 편출된 자산은 스스로 리밸런싱을 트리거해야 함 —
+    'target_w > 0' 가드 때문에 다른 이탈이 생길 때까지 잔여 포지션이
+    무기한 방치되던 버그 회귀 방지"""
+    config = RebalanceConfig(
+        crypto_target=0.60, band_pp=0.05,
+        crypto_weights={"BTC": 0.6, "ETH": 0.3, "XRP": 0.1, "SOL": 0.0},
+        relative_band=0.20, min_trade_krw=10_000,
+    )
+    # 크립토 60M (총 100M의 60%, 밴드 내), SOL만 목표 0인데 6M 보유
+    holdings = {"BTC": 30_000_000, "ETH": 18_000_000,
+                "XRP": 6_000_000, "SOL": 6_000_000}
+    orders = plan_rebalance(config, holdings, krw_balance=40_000_000)
+    by_asset = {o.asset: o for o in orders}
+    assert by_asset["SOL"].side == "sell"
+    assert by_asset["SOL"].amount_krw == pytest.approx(6_000_000)
+
+
+def test_fully_demoted_dust_below_min_trade_ignored():
+    """편출 자산 잔여물이 최소 거래액 미만이면 트리거하지 않음 (먼지 방치 OK)"""
+    config = RebalanceConfig(
+        crypto_target=0.60, band_pp=0.05,
+        crypto_weights={"BTC": 0.6, "ETH": 0.3, "XRP": 0.1, "SOL": 0.0},
+        relative_band=0.20, min_trade_krw=10_000,
+    )
+    holdings = {"BTC": 30_000_000, "ETH": 18_000_000,
+                "XRP": 6_000_000, "SOL": 5_000}
+    assert plan_rebalance(config, holdings, krw_balance=35_995_000) == []


### PR DESCRIPTION
## 배경

전면 코드 리뷰(4개 영역 병렬 + 개별 재검증)에서 발견된 버그 전체를 TDD로 수정. 어제 발견한 스냅샷 키 불일치와 같은 **모듈 간 계약 불일치**가 반복 패턴이었음.

## 🔴 치명 (실거래 손익 직결)

1. **체결 확인·미체결 취소 전면 불능**: `order/info`·`order/cancel`이 v2.1 필수 파라미터 `quote_currency`/`target_currency` 없이 호출됨 → 체결 폴링 항상 0%(체결된 주문을 미체결로 보고 → 다음날 되팔기 루프), 취소 실패로 유령 지정가 방치. 자산을 함께 전달하도록 시그니처 변경.
2. **일일 스냅샷 저장 항상 실패**: INSERT가 CREATE TABLE에 없는 9개 자산별 컬럼에 기록 (재현 확인). 월간 수익률·전일 대비가 영원히 "축적 중"이던 진짜 원인. narrow 스키마에 맞춰 수정 + 구 wide DB 마이그레이션. **테스트 픽스처가 프로덕션 테이블을 drop 후 다른 스키마로 재생성해 버그를 가리고 있었음** — 픽스처도 교정.
3. **크래시 가드·FOMO 가드 무력화**: "24h 변동률"이 일봉 `iloc[-2]` 기준 = UTC 자정 이후 변동 → 09:10 KST(=00:10 UTC) 크론에선 항상 ≈0%. 시간봉 롤링 24시간 창으로 재계산.

## 🟠 높음

4. **이중 주문 방지**: 주문 POST의 네트워크 모호 실패(응답 유실)를 `ambiguous`로 분류해 재시도 중단 (fail-safe). `requests` 호출에 timeout 추가 (`api.coinone.timeout` 연결).
5. **리스크 가드 러닝 잔고**: 배치 내 체결마다 KRW 잔고 갱신 — KRW 하한이 실제로 집행되고, 매도 대금으로 매수가 승인됨 (한쪽 다리 리밸런싱 방지).
6. **조립 단계 크래시 알림**: config·DB·클라이언트 생성 실패도 Slack 통지 (AlertSystem 실패 시 `SLACK_WEBHOOK_URL` 직접 POST 폴백) — briefing 하트비트가 조용히 죽는 실패 클래스 제거.
7. **레이트 리미터 복원**: 명시적 패스스루 메서드가 `__getattr__` 래핑을 가려 전면 데드코드였음. 제거 + 실패 시 이중 호출 폴백 제거 (호출은 정확히 1회).

## 🟡 중간

- 완전 편출(가중치 0) 자산이 스스로 매도 트리거 못 하던 문제 (잔여 포지션 무기한 방치)
- 월간 리포트: BTC 벤치마크를 실제 관측 창(일수)과 일치 + 당일 스냅샷 기준선 배제
- 백테스트 Sharpe·MDD를 시간가중 수익률로 계산 (주간 적립 입금 오염 제거)
- `--dry-run`이 스냅샷을 DB에 기록해 전일 대비 기준선을 오염하던 문제
- info 알림 채널 라우팅 키 정규화 (`system_info` 키 미스로 config `info:` 설정이 죽어 있었음)

## ⚪ 낮음·잠재

- 지정가 `int()` 절삭 제거(1,000 KRW 미만 자산 대비), 수량 지수 표기 방지 (고정 소수점 직렬화)
- 멘션 리스트 in-place 오염 (`@here` 누적) 수정
- `slippage_cap`·`timeout` 설정 연결, example.yaml 죽은 키 제거·누락 키 추가 (briefing 스케줄 포함)
- performance_tracker: trade_history 실제 컬럼 사용(수수료·평균 거래액 항상 0이던 버그), portfolio_detail JSON 기반 배분, 0-분모 inf 방어
- DB 잠재 경로: TWAP 조회 컬럼 불일치, `result_data` 컬럼 부재, `rebalance_results`(미기록 테이블) 조회를 `rebalance_history`로 교정

## 테스트

TDD (Red→Green) — 신규/갱신 테스트 40여 건, 전체 894개 통과. 구 버그 행동을 인코딩한 레거시 테스트는 새 규약으로 갱신.

## 배포 메모

- 코드 pull + 재시작만으로 적용 (DB 마이그레이션은 시작 시 자동)
- EC2의 기존 DB에 과거 total 0 스냅샷 행이 있다면 그대로 무시됨 (기준선에서 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)